### PR TITLE
Feature/8 인증 API 추가

### DIFF
--- a/internal/auth/dto.go
+++ b/internal/auth/dto.go
@@ -25,3 +25,14 @@ type VerifyOtpRequest struct {
 	Email string `json:"email" binding:"required,email"`
 	Otp   string `json:"otp" binding:"required"`
 }
+
+// AuthTokenReissueRequest - 토큰 재발급 요청 DTO
+type AuthTokenReissueRequest struct {
+	RefreshToken string `json:"refreshToken" binding:"required"`
+}
+
+// AuthTokenReissueResponse - 토큰 재발급 응답 DTO
+type AuthTokenReissueResponse struct {
+	AccessToken  string `json:"accessToken"`
+	RefreshToken string `json:"refreshToken"`
+}

--- a/internal/auth/dto.go
+++ b/internal/auth/dto.go
@@ -20,3 +20,8 @@ type LoginResponse struct {
 type EmailOtpRequest struct {
 	Email string `json:"email" binding:"required,email"`
 }
+
+type VerifyOtpRequest struct {
+	Email string `json:"email" binding:"required,email"`
+	Otp   string `json:"otp" binding:"required"`
+}

--- a/internal/auth/dto.go
+++ b/internal/auth/dto.go
@@ -16,3 +16,7 @@ type LoginResponse struct {
 	AccessToken  string `json:"accessToken"`
 	RefreshToken string `json:"refreshToken"`
 }
+
+type EmailOtpRequest struct {
+	Email string `json:"email" binding:"required,email"`
+}

--- a/internal/auth/errors.go
+++ b/internal/auth/errors.go
@@ -8,10 +8,16 @@ import (
 
 const (
 	incorrectEmailPassword = "INCORRECT_EMAIL_PASSWORD" // errInfo
+	refreshTokenNotFound   = "REFRESH_TOKEN_NOT_FOUND"  // errInfo
+	refreshTokenExpired    = "REFRESH_TOKEN_EXPIRED"    // errInfo
+	refreshTokenMismatch   = "REFRESH_TOKEN_MISMATCH"   // errInfo
 )
 
 var (
 	ErrInCorrectEmailPassword = sharedError.NewDomainError(incorrectEmailPassword)
+	ErrRefreshTokenNotFound   = sharedError.NewDomainError(refreshTokenNotFound)
+	ErrRefreshTokenExpired    = sharedError.NewDomainError(refreshTokenExpired)
+	ErrRefreshTokenMismatch   = sharedError.NewDomainError(refreshTokenMismatch)
 )
 
 func init() {
@@ -19,5 +25,23 @@ func init() {
 		Status:  http.StatusBadRequest,
 		Code:    "AUTH-003",
 		Message: "이메일 또는 비밀번호가 일치하지 않습니다.",
+	})
+
+	sharedError.RegisterDomainErrorResponse(refreshTokenNotFound, sharedError.ErrorResponse{
+		Status:  http.StatusUnauthorized,
+		Code:    "AUTH-007",
+		Message: "다시 로그인해 주세요.",
+	})
+
+	sharedError.RegisterDomainErrorResponse(refreshTokenExpired, sharedError.ErrorResponse{
+		Status:  http.StatusUnauthorized,
+		Code:    "AUTH-008",
+		Message: "다시 로그인해 주세요.",
+	})
+
+	sharedError.RegisterDomainErrorResponse(refreshTokenMismatch, sharedError.ErrorResponse{
+		Status:  http.StatusUnauthorized,
+		Code:    "AUTH-009",
+		Message: "다시 로그인해 주세요.",
 	})
 }

--- a/internal/auth/errors.go
+++ b/internal/auth/errors.go
@@ -1,8 +1,9 @@
 package auth
 
 import (
-	sharedError "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/error"
 	"net/http"
+
+	sharedError "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/error"
 )
 
 const (

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"net/http"
+
 	sharedError "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/error"
 	sharedHttp "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/http"
 	"github.com/gin-gonic/gin"
@@ -35,7 +37,7 @@ func (a *AuthHandler) Login(c *gin.Context) {
 		return
 	}
 
-	c.JSON(200, response)
+	c.JSON(http.StatusOK, response)
 }
 
 func (a *AuthHandler) Signup(c *gin.Context) {
@@ -56,5 +58,26 @@ func (a *AuthHandler) Signup(c *gin.Context) {
 		sharedHttp.RespondError(c, err, sharedError.InternalServerError)
 		return
 	}
-	c.JSON(201, gin.H{})
+	c.JSON(http.StatusCreated, gin.H{})
+}
+
+func (a *AuthHandler) RequestEmailOTP(c *gin.Context) {
+	var request EmailOtpRequest
+
+	if !sharedHttp.BindJSON(c, &request) {
+		return
+	}
+
+	response, err := a.authUseCase.RequestEmailOTP(c.Request.Context(), &request)
+	if err != nil {
+		if resp, ok := sharedError.ResolveDomainError(err); ok {
+			sharedHttp.RespondError(c, err, resp)
+			return
+		}
+
+		sharedHttp.RespondError(c, err, sharedError.InternalServerError)
+		return
+	}
+
+	c.JSON(http.StatusOK, response)
 }

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -102,3 +102,23 @@ func (a *AuthHandler) VerifyEmailOTP(c *gin.Context) {
 
 	c.JSON(http.StatusOK, response)
 }
+
+func (a *AuthHandler) Withdraw(c *gin.Context) {
+	memberID, ok := sharedHttp.RequireMemberID(c)
+	if !ok {
+		return
+	}
+
+	response, err := a.authUseCase.Withdraw(c.Request.Context(), memberID)
+	if err != nil {
+		if resp, ok := sharedError.ResolveDomainError(err); ok {
+			sharedHttp.RespondError(c, err, resp)
+			return
+		}
+
+		sharedHttp.RespondError(c, err, sharedError.InternalServerError)
+		return
+	}
+
+	c.JSON(http.StatusOK, response)
+}

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -122,3 +122,24 @@ func (a *AuthHandler) Withdraw(c *gin.Context) {
 
 	c.JSON(http.StatusOK, response)
 }
+
+func (h *AuthHandler) ReissueToken(c *gin.Context) {
+	var request AuthTokenReissueRequest
+
+	if !sharedHttp.BindJSON(c, &request) {
+		return
+	}
+
+	response, err := h.authUseCase.ReissueAuthToken(c.Request.Context(), &request)
+	if err != nil {
+		if resp, ok := sharedError.ResolveDomainError(err); ok {
+			sharedHttp.RespondError(c, err, resp)
+			return
+		}
+
+		sharedHttp.RespondError(c, err, sharedError.InternalServerError)
+		return
+	}
+
+	c.JSON(http.StatusOK, response)
+}

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -123,6 +123,25 @@ func (a *AuthHandler) Withdraw(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
+func (a *AuthHandler) Logout(c *gin.Context) {
+	memberID, ok := sharedHttp.RequireMemberID(c)
+	if !ok {
+		return
+	}
+
+	if err := a.authUseCase.Logout(c.Request.Context(), memberID); err != nil {
+		if resp, ok := sharedError.ResolveDomainError(err); ok {
+			sharedHttp.RespondError(c, err, resp)
+			return
+		}
+
+		sharedHttp.RespondError(c, err, sharedError.InternalServerError)
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}
+
 func (h *AuthHandler) ReissueToken(c *gin.Context) {
 	var request AuthTokenReissueRequest
 

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -81,3 +81,24 @@ func (a *AuthHandler) RequestEmailOTP(c *gin.Context) {
 
 	c.JSON(http.StatusOK, response)
 }
+
+func (a *AuthHandler) VerifyEmailOTP(c *gin.Context) {
+	var request VerifyOtpRequest
+
+	if !sharedHttp.BindJSON(c, &request) {
+		return
+	}
+
+	response, err := a.authUseCase.VerifyEmailOTP(c.Request.Context(), &request)
+	if err != nil {
+		if resp, ok := sharedError.ResolveDomainError(err); ok {
+			sharedHttp.RespondError(c, err, resp)
+			return
+		}
+
+		sharedHttp.RespondError(c, err, sharedError.InternalServerError)
+		return
+	}
+
+	c.JSON(http.StatusOK, response)
+}

--- a/internal/auth/logout_api_test.go
+++ b/internal/auth/logout_api_test.go
@@ -1,0 +1,73 @@
+package auth_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/auth"
+	sharedError "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/error"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogout_Success(t *testing.T) {
+	authHandler, db := setupTestEnvironmentWithDB(t)
+	testMember := testutil.CreateTestMember(t, db)
+	ctx := context.Background()
+
+	refreshTokenRepo := auth.NewRefreshTokenRepository()
+	refreshTokenService := auth.NewRefreshTokenService(refreshTokenRepo)
+
+	expiresAt := time.Now().Add(time.Hour)
+	require.NoError(t, refreshTokenService.Save(ctx, db, testMember.ID, "test-refresh-token", expiresAt))
+
+	router := testutil.SetupAuthenticatedRouter(testMember.ID)
+	router.POST("/api/v1/auth/logout", authHandler.Logout)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodPost,
+		URL:    "/api/v1/auth/logout",
+	})
+
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+	assert.Equal(t, 0, recorder.Body.Len(), "logout should not return a response body")
+
+	exists, err := refreshTokenRepo.Exists(ctx, db, testMember.ID, "test-refresh-token")
+	require.NoError(t, err)
+	assert.False(t, exists, "refresh token should be deleted during logout")
+}
+
+func TestLogout_Unauthenticated(t *testing.T) {
+	authHandler, _ := setupTestEnvironment(t)
+	router := testutil.SetupTestRouter()
+	router.POST("/api/v1/auth/logout", authHandler.Logout)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodPost,
+		URL:    "/api/v1/auth/logout",
+	})
+
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+
+	var errorResponse sharedError.ErrorResponse
+	testutil.ParseResponse(t, recorder, &errorResponse)
+	assert.Equal(t, "AUTH-000", errorResponse.Code)
+}
+
+func TestLogout_SucceedsWithoutRefreshToken(t *testing.T) {
+	authHandler, db := setupTestEnvironmentWithDB(t)
+	testMember := testutil.CreateTestMember(t, db)
+
+	router := testutil.SetupAuthenticatedRouter(testMember.ID)
+	router.POST("/api/v1/auth/logout", authHandler.Logout)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodPost,
+		URL:    "/api/v1/auth/logout",
+	})
+
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+}

--- a/internal/auth/otp/cache.go
+++ b/internal/auth/otp/cache.go
@@ -1,0 +1,54 @@
+package otp
+
+import (
+	"sync"
+	"time"
+)
+
+// Cache defines temporary OTP storage behavior.
+type Cache interface {
+	Set(email, otp string, ttl time.Duration)
+	Get(email string) (string, bool)
+	Delete(email string)
+}
+
+type entry struct {
+	value     string
+	expiresAt time.Time
+}
+
+// InMemoryCache is a goroutine-safe in-memory implementation.
+type InMemoryCache struct {
+	mu    sync.RWMutex
+	items map[string]entry
+}
+
+func NewInMemoryCache() *InMemoryCache {
+	return &InMemoryCache{items: make(map[string]entry)}
+}
+
+func (c *InMemoryCache) Set(email, otp string, ttl time.Duration) {
+	c.mu.Lock()
+	c.items[email] = entry{value: otp, expiresAt: time.Now().Add(ttl)}
+	c.mu.Unlock()
+}
+
+func (c *InMemoryCache) Get(email string) (string, bool) {
+	c.mu.RLock()
+	item, ok := c.items[email]
+	c.mu.RUnlock()
+	if !ok {
+		return "", false
+	}
+	if time.Now().After(item.expiresAt) {
+		c.Delete(email)
+		return "", false
+	}
+	return item.value, true
+}
+
+func (c *InMemoryCache) Delete(email string) {
+	c.mu.Lock()
+	delete(c.items, email)
+	c.mu.Unlock()
+}

--- a/internal/auth/otp/errors.go
+++ b/internal/auth/otp/errors.go
@@ -6,14 +6,25 @@ import (
 	sharedError "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/error"
 )
 
-const otpSendFailed = "OTP_SEND_FAILED"
+const (
+	otpSendFailed = "OTP_SEND_FAILED"
+	otpNotFound   = "OTP_NOT_FOUND"
+)
 
-var ErrSendFailed = sharedError.NewDomainError(otpSendFailed)
+var (
+	ErrSendFailed  = sharedError.NewDomainError(otpSendFailed)
+	ErrOTPNotFound = sharedError.NewDomainError(otpNotFound)
+)
 
 func init() {
 	sharedError.RegisterDomainErrorResponse(otpSendFailed, sharedError.ErrorResponse{
 		Status:  http.StatusBadRequest,
 		Code:    "OTP-001",
 		Message: "인증 번호 발송에 실패했습니다.",
+	})
+	sharedError.RegisterDomainErrorResponse(otpNotFound, sharedError.ErrorResponse{
+		Status:  http.StatusInternalServerError,
+		Code:    "OTP-002",
+		Message: "등록되지 않은 OTP 입니다.",
 	})
 }

--- a/internal/auth/otp/errors.go
+++ b/internal/auth/otp/errors.go
@@ -1,0 +1,19 @@
+package otp
+
+import (
+	"net/http"
+
+	sharedError "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/error"
+)
+
+const otpSendFailed = "OTP_SEND_FAILED"
+
+var ErrSendFailed = sharedError.NewDomainError(otpSendFailed)
+
+func init() {
+	sharedError.RegisterDomainErrorResponse(otpSendFailed, sharedError.ErrorResponse{
+		Status:  http.StatusBadRequest,
+		Code:    "OTP-001",
+		Message: "인증 번호 발송에 실패했습니다.",
+	})
+}

--- a/internal/auth/otp/generator.go
+++ b/internal/auth/otp/generator.go
@@ -1,0 +1,31 @@
+package otp
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+)
+
+// NumericGenerator creates zero-padded numeric OTP strings.
+type NumericGenerator struct {
+	digits int
+}
+
+func NewNumericGenerator(digits int) *NumericGenerator {
+	if digits <= 0 {
+		digits = 6
+	}
+	return &NumericGenerator{digits: digits}
+}
+
+func (g *NumericGenerator) Generate() (string, error) {
+	max := big.NewInt(1)
+	for i := 0; i < g.digits; i++ {
+		max.Mul(max, big.NewInt(10))
+	}
+	value, err := rand.Int(rand.Reader, max)
+	if err != nil {
+		return "", fmt.Errorf("OTP 생성 실패: %w", err)
+	}
+	return fmt.Sprintf("%0*d", g.digits, value.Int64()), nil
+}

--- a/internal/auth/otp/service.go
+++ b/internal/auth/otp/service.go
@@ -1,0 +1,38 @@
+package otp
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Service coordinates OTP generation, caching, and delivery.
+type Service struct {
+	cache     Cache
+	sender    *SMTPSender
+	generator *NumericGenerator
+	ttl       time.Duration
+}
+
+func NewService(cache Cache, sender *SMTPSender, generator *NumericGenerator, ttl time.Duration) *Service {
+	return &Service{cache: cache, sender: sender, generator: generator, ttl: ttl}
+}
+
+func (s *Service) SendToEmail(ctx context.Context, email string) error {
+	otp, err := s.generator.Generate()
+	if err != nil {
+		return fmt.Errorf("OTP 생성 중 오류: %w", err)
+	}
+
+	if err := s.sender.SendOTP(ctx, email, otp); err != nil {
+		return fmt.Errorf("OTP 발송 실패: %v: %w", err, ErrSendFailed)
+	}
+	s.cache.Set(email, otp, s.ttl)
+
+	return nil
+}
+
+// GetCachedOTP는 테스트를 위한 헬퍼입니다.
+func (s *Service) GetCachedOTP(email string) (string, bool) {
+	return s.cache.Get(email)
+}

--- a/internal/auth/otp/service.go
+++ b/internal/auth/otp/service.go
@@ -32,6 +32,24 @@ func (s *Service) SendToEmail(ctx context.Context, email string) error {
 	return nil
 }
 
+// VerifyOTP verifies the OTP for the given email.
+// Returns true if the OTP matches, false otherwise.
+// If no OTP exists for the email, returns an error.
+func (s *Service) VerifyOTP(ctx context.Context, email, otp string) (bool, error) {
+	cachedOTP, exists := s.cache.Get(email)
+	if !exists {
+		return false, fmt.Errorf("등록되지 않은 OTP 입니다: %w", ErrOTPNotFound)
+	}
+
+	if cachedOTP != otp {
+		return false, nil
+	}
+
+	// OTP 일치 시 캐시에서 즉시 삭제 (재사용 방지)
+	s.cache.Delete(email)
+	return true, nil
+}
+
 // GetCachedOTP는 테스트를 위한 헬퍼입니다.
 func (s *Service) GetCachedOTP(email string) (string, bool) {
 	return s.cache.Get(email)

--- a/internal/auth/otp/smtp_sender.go
+++ b/internal/auth/otp/smtp_sender.go
@@ -1,0 +1,87 @@
+package otp
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"html/template"
+	"net/smtp"
+	"path/filepath"
+
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/config"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/logger"
+)
+
+// SMTPSender sends OTP via email using SMTP.
+type SMTPSender struct {
+	config config.SMTPConfig
+}
+
+// NewSMTPSender creates a new SMTP-based OTP sender.
+func NewSMTPSender(cfg config.SMTPConfig) *SMTPSender {
+	return &SMTPSender{
+		config: cfg,
+	}
+}
+
+// SendOTP sends an OTP to the given email address.
+func (s *SMTPSender) SendOTP(ctx context.Context, email, otp string) error {
+	log := logger.FromContext(ctx)
+
+	// Load and parse HTML template
+	htmlBody, err := s.renderTemplate(otp)
+	if err != nil {
+		return fmt.Errorf("OTP 템플릿 로드 실패: %w", err)
+	}
+
+	// Prepare email message
+	subject := "기도함께 이메일 인증번호"
+	message := s.buildMessage(s.config.From, email, subject, htmlBody)
+
+	// SMTP authentication
+	auth := smtp.PlainAuth("", s.config.Username, s.config.Password, s.config.Host)
+
+	// Send email
+	addr := fmt.Sprintf("%s:%d", s.config.Host, s.config.Port)
+	err = smtp.SendMail(addr, auth, s.config.From, []string{email}, []byte(message))
+	if err != nil {
+		return fmt.Errorf("OTP 이메일 발송 실패: email=%s %w", logger.MaskEmail(email), err)
+	}
+
+	log.Info("OTP 발송 성공", "email", logger.MaskEmail(email))
+	return nil
+}
+
+// renderTemplate loads and renders the OTP HTML template.
+func (s *SMTPSender) renderTemplate(otp string) (string, error) {
+	tmpl, err := template.ParseFiles(GetDefaultTemplatePath())
+	if err != nil {
+		return "", fmt.Errorf("템플릿 파일 읽기 실패: %w", err)
+	}
+
+	var buf bytes.Buffer
+	data := map[string]string{"OTP": otp}
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("템플릿 렌더링 실패: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// buildMessage constructs the email message with headers.
+func (s *SMTPSender) buildMessage(from, to, subject, htmlBody string) string {
+	headers := fmt.Sprintf("From: %s\r\n"+
+		"To: %s\r\n"+
+		"Subject: %s\r\n"+
+		"MIME-Version: 1.0\r\n"+
+		"Content-Type: text/html; charset=UTF-8\r\n"+
+		"\r\n",
+		from, to, subject)
+
+	return headers + htmlBody
+}
+
+// GetDefaultTemplatePath returns the default template path.
+func GetDefaultTemplatePath() string {
+	return filepath.Join("templates", "email", "otp.html")
+}

--- a/internal/auth/refresh_token_repository.go
+++ b/internal/auth/refresh_token_repository.go
@@ -1,0 +1,65 @@
+package auth
+
+import (
+	"context"
+	"time"
+
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/model"
+	"gorm.io/gorm"
+)
+
+// RefreshTokenRepository - RefreshToken 데이터 접근 계층
+type RefreshTokenRepository struct {
+}
+
+// NewRefreshTokenRepository - RefreshTokenRepository 생성자
+func NewRefreshTokenRepository() *RefreshTokenRepository {
+	return &RefreshTokenRepository{}
+}
+
+// Save - Refresh Token 저장 (기존 토큰이 있으면 삭제 후 저장)
+// 회원당 하나의 Refresh Token만 유지
+func (r *RefreshTokenRepository) Save(ctx context.Context, db *gorm.DB, memberID int64, token string, expiresAt time.Time) error {
+	// 기존 토큰 삭제 (존재하지 않아도 에러 없음)
+	_ = r.Delete(ctx, db, memberID)
+
+	// 새로운 토큰 저장
+	refreshToken := model.NewRefreshToken(memberID, token, expiresAt)
+	return db.WithContext(ctx).Create(refreshToken).Error
+}
+
+// FindByMemberID - MemberID로 RefreshToken 조회
+func (r *RefreshTokenRepository) FindByMemberID(ctx context.Context, db *gorm.DB, memberID int64) (*model.RefreshToken, error) {
+	var refreshToken model.RefreshToken
+	err := db.WithContext(ctx).
+		Where("member_id = ?", memberID).
+		First(&refreshToken).Error
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &refreshToken, nil
+}
+
+// Delete - MemberID로 RefreshToken 삭제
+func (r *RefreshTokenRepository) Delete(ctx context.Context, db *gorm.DB, memberID int64) error {
+	return db.WithContext(ctx).
+		Where("member_id = ?", memberID).
+		Delete(&model.RefreshToken{}).Error
+}
+
+// Exists - MemberID로 RefreshToken 존재 여부 확인
+func (r *RefreshTokenRepository) Exists(ctx context.Context, db *gorm.DB, memberID int64, token string) (bool, error) {
+	var count int64
+	err := db.WithContext(ctx).
+		Model(&model.RefreshToken{}).
+		Where("member_id = ? AND token = ?", memberID, token).
+		Count(&count).Error
+
+	if err != nil {
+		return false, err
+	}
+
+	return count > 0, nil
+}

--- a/internal/auth/refresh_token_service.go
+++ b/internal/auth/refresh_token_service.go
@@ -1,0 +1,61 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// RefreshTokenService - RefreshToken 비즈니스 로직 계층
+type RefreshTokenService struct {
+	repo *RefreshTokenRepository
+}
+
+// NewRefreshTokenService - RefreshTokenService 생성자
+func NewRefreshTokenService(repo *RefreshTokenRepository) *RefreshTokenService {
+	return &RefreshTokenService{
+		repo: repo,
+	}
+}
+
+// Save - Refresh Token 저장
+func (s *RefreshTokenService) Save(ctx context.Context, db *gorm.DB, memberID int64, token string, expiresAt time.Time) error {
+	return s.repo.Save(ctx, db, memberID, token, expiresAt)
+}
+
+// ValidateExist - Refresh Token 존재 및 유효성 검증
+func (s *RefreshTokenService) ValidateExist(ctx context.Context, db *gorm.DB, memberID int64, requestToken string) error {
+	// 저장된 토큰 조회
+	storedToken, err := s.repo.FindByMemberID(ctx, db, memberID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("RefreshToken 조회 실패: %w", ErrRefreshTokenNotFound)
+		}
+		return fmt.Errorf("RefreshToken 조회 중 오류 발생: %w", err)
+	}
+
+	// 만료 여부 확인
+	if storedToken.IsExpired() {
+		// 만료된 토큰 삭제
+		_ = s.repo.Delete(ctx, db, memberID)
+		return fmt.Errorf("RefreshToken 만료: %w", ErrRefreshTokenExpired)
+	}
+
+	// 토큰 값 일치 여부 확인
+	if storedToken.Token != requestToken {
+		return fmt.Errorf("RefreshToken 불일치: %w", ErrRefreshTokenMismatch)
+	}
+
+	return nil
+}
+
+// Delete - Refresh Token 삭제
+func (s *RefreshTokenService) Delete(ctx context.Context, db *gorm.DB, memberID int64) error {
+	if err := s.repo.Delete(ctx, db, memberID); err != nil {
+		return fmt.Errorf("RefreshToken 삭제 실패: %w", err)
+	}
+	return nil
+}

--- a/internal/auth/reissue_token_api_test.go
+++ b/internal/auth/reissue_token_api_test.go
@@ -1,0 +1,234 @@
+package auth_test
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/auth"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestReissueToken_Success - 토큰 재발급 성공 테스트
+func TestReissueToken_Success(t *testing.T) {
+	// Given: 테스트 환경 설정
+	authHandler, db := setupTestEnvironmentWithDB(t)
+
+	// 테스트 회원 생성
+	member := testutil.CreateTestMember(t, db)
+	memberIDStr := strconv.FormatInt(member.ID, 10)
+
+	// 실제 JWT Manager 생성 (토큰 발급/검증을 위해)
+	cfg := testutil.NewTestConfig()
+	tokenManager := testutil.NewRealJWTManager(cfg)
+
+	// Refresh Token 생성 및 저장
+	refreshToken, err := tokenManager.GenerateRefreshToken(memberIDStr, member.Email)
+	assert.NoError(t, err)
+
+	// Refresh Token 저장
+	refreshTokenRepo := auth.NewRefreshTokenRepository()
+	refreshTokenService := auth.NewRefreshTokenService(refreshTokenRepo)
+	expiresAt, err := tokenManager.ExtractExpiration(refreshToken)
+	assert.NoError(t, err)
+	err = refreshTokenService.Save(context.Background(), db, member.ID, refreshToken, expiresAt)
+	assert.NoError(t, err)
+
+	// When: 토큰 재발급 요청
+	router := testutil.SetupTestRouter()
+	router.POST("/api/v1/auth/reissue-token", authHandler.ReissueToken)
+
+	request := testutil.TestRequest{
+		Method: http.MethodPost,
+		URL:    "/api/v1/auth/reissue-token",
+		Body: map[string]interface{}{
+			"refreshToken": refreshToken,
+		},
+	}
+
+	recorder := testutil.ExecuteRequest(t, router, request)
+
+	// Then: 응답 검증
+	assert.Equal(t, http.StatusOK, recorder.Code, "Expected HTTP 200 OK for successful token reissue")
+
+	var response auth.AuthTokenReissueResponse
+	testutil.ParseResponse(t, recorder, &response)
+
+	assert.NotEmpty(t, response.AccessToken, "Access token should not be empty")
+	assert.NotEmpty(t, response.RefreshToken, "Refresh token should not be empty")
+	assert.NotEmpty(t, response.RefreshToken, "New refresh token should not be empty")
+}
+
+// TestReissueToken_InvalidToken - 유효하지 않은 토큰으로 재발급 시도
+func TestReissueToken_InvalidToken(t *testing.T) {
+	// Given: 테스트 환경 설정
+	authHandler, db := setupTestEnvironmentWithDB(t)
+
+	// 존재하지 않는 memberID로 토큰 생성 (JWT 형식은 맞지만 member가 없음)
+	cfg := testutil.NewTestConfig()
+	tokenManager := testutil.NewRealJWTManager(cfg)
+	invalidToken, err := tokenManager.GenerateRefreshToken("99999", "nonexistent@example.com")
+	assert.NoError(t, err)
+
+	// When: 존재하지 않는 member의 토큰으로 재발급 요청
+	router := testutil.SetupTestRouter()
+	router.POST("/api/v1/auth/reissue-token", authHandler.ReissueToken)
+
+	request := testutil.TestRequest{
+		Method: http.MethodPost,
+		URL:    "/api/v1/auth/reissue-token",
+		Body: map[string]interface{}{
+			"refreshToken": invalidToken,
+		},
+	}
+
+	recorder := testutil.ExecuteRequest(t, router, request)
+
+	// Then: 404 Not Found 응답 검증 (member가 존재하지 않음)
+	assert.Equal(t, http.StatusNotFound, recorder.Code, "Expected HTTP 404 Not Found for non-existent member")
+
+	_ = db // Suppress unused variable warning
+}
+
+// TestReissueToken_TokenNotFound - DB에 저장되지 않은 토큰으로 재발급 시도
+func TestReissueToken_TokenNotFound(t *testing.T) {
+	// Given: 테스트 환경 설정
+	authHandler, db := setupTestEnvironmentWithDB(t)
+
+	// 테스트 회원 생성
+	member := testutil.CreateTestMember(t, db)
+	memberIDStr := strconv.FormatInt(member.ID, 10)
+
+	// 실제 JWT Manager 생성
+	cfg := testutil.NewTestConfig()
+	tokenManager := testutil.NewRealJWTManager(cfg)
+
+	// Refresh Token 생성 (하지만 DB에 저장하지 않음)
+	refreshToken, err := tokenManager.GenerateRefreshToken(memberIDStr, member.Email)
+	assert.NoError(t, err)
+
+	// When: DB에 저장되지 않은 토큰으로 재발급 요청
+	router := testutil.SetupTestRouter()
+	router.POST("/api/v1/auth/reissue-token", authHandler.ReissueToken)
+
+	request := testutil.TestRequest{
+		Method: http.MethodPost,
+		URL:    "/api/v1/auth/reissue-token",
+		Body: map[string]interface{}{
+			"refreshToken": refreshToken,
+		},
+	}
+
+	recorder := testutil.ExecuteRequest(t, router, request)
+
+	// Then: 401 Unauthorized 응답 검증
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code, "Expected HTTP 401 Unauthorized for token not found")
+}
+
+// TestReissueToken_ExpiredToken - 만료된 토큰으로 재발급 시도
+func TestReissueToken_ExpiredToken(t *testing.T) {
+	// Given: 테스트 환경 설정
+	authHandler, db := setupTestEnvironmentWithDB(t)
+
+	// 테스트 회원 생성
+	member := testutil.CreateTestMember(t, db)
+
+	// 만료된 토큰을 DB에 저장
+	refreshTokenRepo := auth.NewRefreshTokenRepository()
+	refreshTokenService := auth.NewRefreshTokenService(refreshTokenRepo)
+	expiredToken := "expired.token.here"
+	expiredTime := time.Now().Add(-1 * time.Hour) // 1시간 전에 만료
+	err := refreshTokenService.Save(context.Background(), db, member.ID, expiredToken, expiredTime)
+	assert.NoError(t, err)
+
+	// When: 만료된 토큰으로 재발급 요청
+	router := testutil.SetupTestRouter()
+	router.POST("/api/v1/auth/reissue-token", authHandler.ReissueToken)
+
+	request := testutil.TestRequest{
+		Method: http.MethodPost,
+		URL:    "/api/v1/auth/reissue-token",
+		Body: map[string]interface{}{
+			"refreshToken": expiredToken,
+		},
+	}
+
+	recorder := testutil.ExecuteRequest(t, router, request)
+
+	// Then: 401 Unauthorized 응답 검증
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code, "Expected HTTP 401 Unauthorized for expired token")
+}
+
+// TestReissueToken_TokenMismatch - 다른 회원의 토큰으로 재발급 시도
+func TestReissueToken_TokenMismatch(t *testing.T) {
+	// Given: 테스트 환경 설정
+	authHandler, db := setupTestEnvironmentWithDB(t)
+
+	// 두 명의 회원 생성
+	member1 := testutil.CreateTestMemberWithIndex(t, db, 0)
+	member2 := testutil.CreateTestMemberWithIndex(t, db, 1)
+
+	// 실제 JWT Manager 생성
+	cfg := testutil.NewTestConfig()
+	tokenManager := testutil.NewRealJWTManager(cfg)
+
+	// member1의 토큰 생성
+	memberID1Str := strconv.FormatInt(member1.ID, 10)
+	refreshToken1, err := tokenManager.GenerateRefreshToken(memberID1Str, member1.Email)
+	assert.NoError(t, err)
+
+	// member2의 토큰을 DB에 저장 (다른 토큰)
+	memberID2Str := strconv.FormatInt(member2.ID, 10)
+	refreshToken2, err := tokenManager.GenerateRefreshToken(memberID2Str, member2.Email)
+	assert.NoError(t, err)
+
+	refreshTokenRepo := auth.NewRefreshTokenRepository()
+	refreshTokenService := auth.NewRefreshTokenService(refreshTokenRepo)
+	expiresAt, err := tokenManager.ExtractExpiration(refreshToken2)
+	assert.NoError(t, err)
+	err = refreshTokenService.Save(context.Background(), db, member1.ID, refreshToken2, expiresAt) // member1의 ID로 저장
+	assert.NoError(t, err)
+
+	// When: member1의 실제 토큰으로 재발급 요청 (하지만 DB에는 다른 토큰이 저장됨)
+	router := testutil.SetupTestRouter()
+	router.POST("/api/v1/auth/reissue-token", authHandler.ReissueToken)
+
+	request := testutil.TestRequest{
+		Method: http.MethodPost,
+		URL:    "/api/v1/auth/reissue-token",
+		Body: map[string]interface{}{
+			"refreshToken": refreshToken1, // DB에 저장된 것과 다른 토큰
+		},
+	}
+
+	recorder := testutil.ExecuteRequest(t, router, request)
+
+	// Then: 401 Unauthorized 응답 검증
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code, "Expected HTTP 401 Unauthorized for token mismatch")
+}
+
+// TestReissueToken_MissingRefreshToken - RefreshToken 누락
+func TestReissueToken_MissingRefreshToken(t *testing.T) {
+	// Given: 테스트 환경 설정
+	authHandler, _ := setupTestEnvironmentWithDB(t)
+
+	// When: RefreshToken 없이 요청
+	router := testutil.SetupTestRouter()
+	router.POST("/api/v1/auth/reissue-token", authHandler.ReissueToken)
+
+	request := testutil.TestRequest{
+		Method: http.MethodPost,
+		URL:    "/api/v1/auth/reissue-token",
+		Body:   map[string]interface{}{
+			// refreshToken 필드 누락
+		},
+	}
+
+	recorder := testutil.ExecuteRequest(t, router, request)
+
+	// Then: 400 Bad Request 응답 검증
+	assert.Equal(t, http.StatusBadRequest, recorder.Code, "Expected HTTP 400 Bad Request for missing refresh token")
+}

--- a/internal/auth/signup_api_test.go
+++ b/internal/auth/signup_api_test.go
@@ -1,11 +1,13 @@
 package auth_test
 
 import (
-	"github.com/changhyeonkim/pray-together/go-api-server/internal/member"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/auth"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/auth/otp"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/member"
 	sharedError "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/error"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/testutil"
 	"github.com/stretchr/testify/assert"
@@ -23,11 +25,17 @@ func setupTestEnvironment(t *testing.T) (*auth.AuthHandler, *testutil.MockTokenM
 	})
 
 	// Setup dependencies
-	memberRepo := member.NewMemberRepository(db)
+	memberRepo := member.NewMemberRepository()
 	memberService := testutil.NewMemberService(memberRepo)
 	mockTokenManager := testutil.NewMockTokenManager()
 	authService := auth.NewAuthService()
-	authUseCase := auth.NewAuthUseCase(db, memberService, mockTokenManager, authService)
+	otpService := otp.NewService(
+		otp.NewInMemoryCache(),
+		otp.NewSMTPSender(),
+		otp.NewNumericGenerator(6),
+		time.Minute,
+	)
+	authUseCase := auth.NewAuthUseCase(db, memberService, mockTokenManager, authService, otpService)
 	authHandler := auth.NewAuthHandler(authUseCase)
 
 	return authHandler, mockTokenManager

--- a/internal/auth/signup_api_test.go
+++ b/internal/auth/signup_api_test.go
@@ -3,43 +3,13 @@ package auth_test
 import (
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/auth"
-	"github.com/changhyeonkim/pray-together/go-api-server/internal/auth/otp"
-	"github.com/changhyeonkim/pray-together/go-api-server/internal/member"
 	sharedError "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/error"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// setupTestEnvironment creates all dependencies needed for auth handler tests
-func setupTestEnvironment(t *testing.T) (*auth.AuthHandler, *testutil.MockTokenManager) {
-	t.Helper()
-
-	// Setup test database
-	db := testutil.SetupTestDB(t)
-	t.Cleanup(func() {
-		testutil.CleanupTestDB(t, db)
-	})
-
-	// Setup dependencies
-	memberRepo := member.NewMemberRepository()
-	memberService := testutil.NewMemberService(memberRepo)
-	mockTokenManager := testutil.NewMockTokenManager()
-	authService := auth.NewAuthService()
-	otpService := otp.NewService(
-		otp.NewInMemoryCache(),
-		otp.NewSMTPSender(),
-		otp.NewNumericGenerator(6),
-		time.Minute,
-	)
-	authUseCase := auth.NewAuthUseCase(db, memberService, mockTokenManager, authService, otpService)
-	authHandler := auth.NewAuthHandler(authUseCase)
-
-	return authHandler, mockTokenManager
-}
 
 func TestSignup_Success(t *testing.T) {
 	// Given: Setup test environment

--- a/internal/auth/test_helpers_test.go
+++ b/internal/auth/test_helpers_test.go
@@ -1,0 +1,57 @@
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/auth"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/testutil"
+	"gorm.io/gorm"
+)
+
+// setupTestEnvironment creates all dependencies needed for auth handler tests
+// Returns the handler, mock token manager
+func setupTestEnvironment(t *testing.T) (*auth.AuthHandler, *testutil.MockTokenManager) {
+	t.Helper()
+
+	// Setup test database
+	db := testutil.SetupTestDB(t)
+	t.Cleanup(func() {
+		testutil.CleanupTestDB(t, db)
+	})
+
+	// Setup dependencies with mock SMTP
+	memberRepo := testutil.NewMemberRepository(db)
+	memberService := testutil.NewMemberService(memberRepo)
+	mockTokenManager := testutil.NewMockTokenManager()
+	authService := auth.NewAuthService()
+	otpService, _ := testutil.NewTestOTPService()
+
+	authUseCase := auth.NewAuthUseCase(db, memberService, mockTokenManager, authService, otpService)
+	authHandler := auth.NewAuthHandler(authUseCase)
+
+	return authHandler, mockTokenManager
+}
+
+// setupTestEnvironmentWithDB creates test environment and returns DB for direct access
+// Use this when you need to interact with the database directly in tests
+func setupTestEnvironmentWithDB(t *testing.T) (*auth.AuthHandler, *gorm.DB) {
+	t.Helper()
+
+	// Setup test database
+	db := testutil.SetupTestDB(t)
+	t.Cleanup(func() {
+		testutil.CleanupTestDB(t, db)
+	})
+
+	// Setup dependencies
+	memberRepo := testutil.NewMemberRepository(db)
+	memberService := testutil.NewMemberService(memberRepo)
+	mockTokenManager := testutil.NewMockTokenManager()
+	authService := auth.NewAuthService()
+	otpService, _ := testutil.NewTestOTPService()
+
+	authUseCase := auth.NewAuthUseCase(db, memberService, mockTokenManager, authService, otpService)
+	authHandler := auth.NewAuthHandler(authUseCase)
+
+	return authHandler, db
+}

--- a/internal/auth/test_helpers_test.go
+++ b/internal/auth/test_helpers_test.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/auth"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/testutil"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/token"
 	"gorm.io/gorm"
 )
 
 // setupTestEnvironment creates all dependencies needed for auth handler tests
 // Returns the handler, mock token manager
-func setupTestEnvironment(t *testing.T) (*auth.AuthHandler, *testutil.MockTokenManager) {
+func setupTestEnvironment(t *testing.T) (*auth.AuthHandler, *token.JWTManager) {
 	t.Helper()
 
 	// Setup test database
@@ -19,14 +20,17 @@ func setupTestEnvironment(t *testing.T) (*auth.AuthHandler, *testutil.MockTokenM
 		testutil.CleanupTestDB(t, db)
 	})
 
+	config := testutil.NewTestConfig()
 	// Setup dependencies with mock SMTP
-	memberRepo := testutil.NewMemberRepository(db)
+	memberRepo := testutil.NewMemberRepository()
 	memberService := testutil.NewMemberService(memberRepo)
-	mockTokenManager := testutil.NewMockTokenManager()
+	mockTokenManager := testutil.NewRealJWTManager(config)
 	authService := auth.NewAuthService()
 	otpService, _ := testutil.NewTestOTPService()
+	refreshTokenRepo := auth.NewRefreshTokenRepository()
+	refreshTokenService := auth.NewRefreshTokenService(refreshTokenRepo)
 
-	authUseCase := auth.NewAuthUseCase(db, memberService, mockTokenManager, authService, otpService)
+	authUseCase := auth.NewAuthUseCase(db, memberService, mockTokenManager, authService, otpService, refreshTokenService)
 	authHandler := auth.NewAuthHandler(authUseCase)
 
 	return authHandler, mockTokenManager
@@ -43,14 +47,17 @@ func setupTestEnvironmentWithDB(t *testing.T) (*auth.AuthHandler, *gorm.DB) {
 		testutil.CleanupTestDB(t, db)
 	})
 
+	config := testutil.NewTestConfig()
 	// Setup dependencies
-	memberRepo := testutil.NewMemberRepository(db)
+	memberRepo := testutil.NewMemberRepository()
 	memberService := testutil.NewMemberService(memberRepo)
-	mockTokenManager := testutil.NewMockTokenManager()
+	mockTokenManager := testutil.NewRealJWTManager(config)
 	authService := auth.NewAuthService()
 	otpService, _ := testutil.NewTestOTPService()
+	refreshTokenRepo := auth.NewRefreshTokenRepository()
+	refreshTokenService := auth.NewRefreshTokenService(refreshTokenRepo)
 
-	authUseCase := auth.NewAuthUseCase(db, memberService, mockTokenManager, authService, otpService)
+	authUseCase := auth.NewAuthUseCase(db, memberService, mockTokenManager, authService, otpService, refreshTokenService)
 	authHandler := auth.NewAuthHandler(authUseCase)
 
 	return authHandler, db

--- a/internal/auth/usecase.go
+++ b/internal/auth/usecase.go
@@ -151,6 +151,23 @@ func (u *AuthUseCase) Withdraw(ctx context.Context, memberID int64) (*sharedHttp
 	return &sharedHttp.MessageResponse{Message: "회원 탈퇴를 완료했습니다.\n 함께 기도해 주셔 감사합니다."}, nil
 }
 
+func (u *AuthUseCase) Logout(ctx context.Context, memberID int64) error {
+	log := logger.FromContext(ctx)
+	log.Info("회원 로그아웃 시도", "memberID", memberID)
+
+	if err := database.WithTransaction(ctx, u.db, func(tx *gorm.DB) error {
+		if err := u.refreshTokenService.Delete(ctx, tx, memberID); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	log.Info("회원 로그아웃 성공", "memberID", memberID)
+	return nil
+}
+
 // ReissueAuthToken - Refresh Token을 사용하여 Access Token과 Refresh Token 재발급
 func (u *AuthUseCase) ReissueAuthToken(ctx context.Context, request *AuthTokenReissueRequest) (*AuthTokenReissueResponse, error) {
 	var newAccessToken string

--- a/internal/auth/usecase.go
+++ b/internal/auth/usecase.go
@@ -17,26 +17,26 @@ import (
 
 // AuthUseCase orchestrates auth-specific application logic.
 type AuthUseCase struct {
-	db            *gorm.DB
-	memberService *member.MemberService
-	tokenManager  token.Manager
-	authService   *AuthService
-	otpService    *otp.Service
+	db                  *gorm.DB
+	memberService       *member.MemberService
+	tokenManager        token.Manager
+	authService         *AuthService
+	otpService          *otp.Service
+	refreshTokenService *RefreshTokenService
 }
 
-func NewAuthUseCase(db *gorm.DB, memberService *member.MemberService, tokenManager token.Manager, authService *AuthService, otpService *otp.Service) *AuthUseCase {
+func NewAuthUseCase(db *gorm.DB, memberService *member.MemberService, tokenManager token.Manager, authService *AuthService, otpService *otp.Service, refreshTokenService *RefreshTokenService) *AuthUseCase {
 	return &AuthUseCase{
-		db:            db,
-		memberService: memberService,
-		tokenManager:  tokenManager,
-		authService:   authService,
-		otpService:    otpService,
+		db:                  db,
+		memberService:       memberService,
+		tokenManager:        tokenManager,
+		authService:         authService,
+		otpService:          otpService,
+		refreshTokenService: refreshTokenService,
 	}
 }
 
 func (u *AuthUseCase) Login(ctx context.Context, request *LoginRequest) (*LoginResponse, error) {
-	log := logger.FromContext(ctx)
-
 	foundMember, err := u.memberService.GetByEmail(ctx, u.db, request.Email)
 	if err != nil {
 		return nil, err
@@ -47,7 +47,7 @@ func (u *AuthUseCase) Login(ctx context.Context, request *LoginRequest) (*LoginR
 	}
 
 	memberID := strconv.FormatInt(foundMember.ID, 10)
-	accessToken, err := u.tokenManager.GenerateAccessToken(memberID, foundMember.Email) // todo : token manager err
+	accessToken, err := u.tokenManager.GenerateAccessToken(memberID, foundMember.Email)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,15 @@ func (u *AuthUseCase) Login(ctx context.Context, request *LoginRequest) (*LoginR
 		return nil, err
 	}
 
-	log.Info("로그인 성공", "email", logger.MaskEmail(request.Email))
+	// Refresh Token의 만료 시각 추출 및 저장
+	expiresAt, err := u.tokenManager.ExtractExpiration(refreshToken)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := u.refreshTokenService.Save(ctx, u.db, foundMember.ID, refreshToken, expiresAt); err != nil {
+		return nil, fmt.Errorf("RefreshToken 저장 실패: %w", err)
+	}
 
 	return &LoginResponse{
 		AccessToken:  accessToken,
@@ -141,4 +149,73 @@ func (u *AuthUseCase) Withdraw(ctx context.Context, memberID int64) (*sharedHttp
 	}
 
 	return &sharedHttp.MessageResponse{Message: "회원 탈퇴를 완료했습니다.\n 함께 기도해 주셔 감사합니다."}, nil
+}
+
+// ReissueAuthToken - Refresh Token을 사용하여 Access Token과 Refresh Token 재발급
+func (u *AuthUseCase) ReissueAuthToken(ctx context.Context, request *AuthTokenReissueRequest) (*AuthTokenReissueResponse, error) {
+	var newAccessToken string
+	var newRefreshToken string
+
+	err := database.WithTransaction(ctx, u.db, func(tx *gorm.DB) error {
+		// 1. Refresh Token에서 memberID 추출
+		memberID, err := u.tokenManager.ExtractMemberID(request.RefreshToken)
+		if err != nil {
+			return err
+		}
+
+		// 2. Member 존재 확인
+		foundMember, err := u.memberService.GetByID(ctx, tx, memberID)
+		if err != nil {
+			return err
+		}
+
+		// 3. DB에 저장된 RefreshToken 검증
+		if err := u.refreshTokenService.ValidateExist(ctx, tx, memberID, request.RefreshToken); err != nil {
+			return err
+		}
+
+		// 4. JWT 토큰 검증
+		if _, err := u.tokenManager.ValidateToken(request.RefreshToken); err != nil {
+			return err
+		}
+
+		// 5. 새로운 토큰 생성
+		memberIDStr := strconv.FormatInt(memberID, 10)
+		generatedAccess, err := u.tokenManager.GenerateAccessToken(memberIDStr, foundMember.Email)
+		if err != nil {
+			return err
+		}
+		newAccessToken = generatedAccess
+
+		generatedRefresh, err := u.tokenManager.GenerateRefreshToken(memberIDStr, foundMember.Email)
+		if err != nil {
+			return err
+		}
+		newRefreshToken = generatedRefresh
+
+		expiresAt, err := u.tokenManager.ExtractExpiration(generatedRefresh)
+		if err != nil {
+			return err
+		}
+
+		// 6. 기존 토큰 삭제 및 새 토큰 저장
+		if err := u.refreshTokenService.Delete(ctx, tx, memberID); err != nil {
+			return err
+		}
+
+		if err := u.refreshTokenService.Save(ctx, tx, memberID, generatedRefresh, expiresAt); err != nil {
+			return fmt.Errorf("RefreshToken 저장 실패: %w", err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &AuthTokenReissueResponse{
+		AccessToken:  newAccessToken,
+		RefreshToken: newRefreshToken,
+	}, nil
 }

--- a/internal/auth/usecase.go
+++ b/internal/auth/usecase.go
@@ -85,6 +85,8 @@ func (u *AuthUseCase) Signup(ctx context.Context, request *SignupRequest) error 
 }
 
 func (u *AuthUseCase) RequestEmailOTP(ctx context.Context, request *EmailOtpRequest) (*sharedHttp.MessageResponse, error) {
+	log := logger.FromContext(ctx)
+
 	exists, err := u.memberService.ExistsByEmail(ctx, u.db, request.Email)
 	if err != nil {
 		return nil, err
@@ -95,8 +97,28 @@ func (u *AuthUseCase) RequestEmailOTP(ctx context.Context, request *EmailOtpRequ
 	}
 
 	if err := u.otpService.SendToEmail(ctx, request.Email); err != nil {
+		log.Error("OTP 발송 실패", "email", logger.MaskEmail(request.Email), "error", err)
 		return nil, err
 	}
 
+	log.Info("OTP 발송 성공", "email", logger.MaskEmail(request.Email))
 	return &sharedHttp.MessageResponse{Message: "인증 번호를 요청했습니다."}, nil
+}
+
+func (u *AuthUseCase) VerifyEmailOTP(ctx context.Context, request *VerifyOtpRequest) (*sharedHttp.MessageResponse, error) {
+	log := logger.FromContext(ctx)
+
+	isValid, err := u.otpService.VerifyOTP(ctx, request.Email, request.Otp)
+	if err != nil {
+		log.Error("OTP 검증 실패", "email", logger.MaskEmail(request.Email), "error", err)
+		return nil, err
+	}
+
+	if !isValid {
+		log.Warn("OTP 불일치", "email", logger.MaskEmail(request.Email))
+		return &sharedHttp.MessageResponse{Message: "인증 번호가 일치하지 않습니다."}, nil
+	}
+
+	log.Info("OTP 검증 성공", "email", logger.MaskEmail(request.Email))
+	return &sharedHttp.MessageResponse{Message: "인증에 성공했습니다."}, nil
 }

--- a/internal/auth/usecase.go
+++ b/internal/auth/usecase.go
@@ -122,3 +122,23 @@ func (u *AuthUseCase) VerifyEmailOTP(ctx context.Context, request *VerifyOtpRequ
 	log.Info("OTP 검증 성공", "email", logger.MaskEmail(request.Email))
 	return &sharedHttp.MessageResponse{Message: "인증에 성공했습니다."}, nil
 }
+
+func (u *AuthUseCase) Withdraw(ctx context.Context, memberID int64) (*sharedHttp.MessageResponse, error) {
+	log := logger.FromContext(ctx)
+
+	err := database.WithTransaction(ctx, u.db, func(tx *gorm.DB) error {
+		if err := u.memberService.DeleteMember(ctx, tx, memberID); err != nil {
+			log.Error("회원 탈퇴 실패", "memberID", memberID, "error", err)
+			return err
+		}
+
+		log.Info("회원 탈퇴 성공", "memberID", memberID)
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &sharedHttp.MessageResponse{Message: "회원 탈퇴를 완료했습니다.\n 함께 기도해 주셔 감사합니다."}, nil
+}

--- a/internal/auth/usecase.go
+++ b/internal/auth/usecase.go
@@ -2,11 +2,14 @@ package auth
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/auth/otp"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/member"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/model"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/database"
+	sharedHttp "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/http"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/logger"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/token"
 	"gorm.io/gorm"
@@ -18,14 +21,16 @@ type AuthUseCase struct {
 	memberService *member.MemberService
 	tokenManager  token.Manager
 	authService   *AuthService
+	otpService    *otp.Service
 }
 
-func NewAuthUseCase(db *gorm.DB, memberService *member.MemberService, tokenManager token.Manager, authService *AuthService) *AuthUseCase {
+func NewAuthUseCase(db *gorm.DB, memberService *member.MemberService, tokenManager token.Manager, authService *AuthService, otpService *otp.Service) *AuthUseCase {
 	return &AuthUseCase{
 		db:            db,
 		memberService: memberService,
 		tokenManager:  tokenManager,
 		authService:   authService,
+		otpService:    otpService,
 	}
 }
 
@@ -77,4 +82,21 @@ func (u *AuthUseCase) Signup(ctx context.Context, request *SignupRequest) error 
 		log.Info("Member created successfully", "email", logger.MaskEmail(request.Email))
 		return nil
 	})
+}
+
+func (u *AuthUseCase) RequestEmailOTP(ctx context.Context, request *EmailOtpRequest) (*sharedHttp.MessageResponse, error) {
+	exists, err := u.memberService.ExistsByEmail(ctx, u.db, request.Email)
+	if err != nil {
+		return nil, err
+	}
+
+	if exists {
+		return nil, fmt.Errorf("이미 존재하는 이메일입니다: %w", member.ErrMemberAlreadyExists)
+	}
+
+	if err := u.otpService.SendToEmail(ctx, request.Email); err != nil {
+		return nil, err
+	}
+
+	return &sharedHttp.MessageResponse{Message: "인증 번호를 요청했습니다."}, nil
 }

--- a/internal/auth/withdraw_api_test.go
+++ b/internal/auth/withdraw_api_test.go
@@ -1,0 +1,127 @@
+package auth_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/member"
+	sharedError "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/error"
+	sharedHttp "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/http"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithdraw_Success(t *testing.T) {
+	// Given: Setup test environment
+	authHandler, db := setupTestEnvironmentWithDB(t)
+
+	// Create test member
+	testMember := testutil.CreateTestMember(t, db)
+	router := testutil.SetupAuthenticatedRouter(testMember.ID)
+	router.DELETE("/api/v1/auth/withdraw", authHandler.Withdraw)
+
+	// When: Execute withdraw request
+	request := testutil.TestRequest{
+		Method: http.MethodDelete,
+		URL:    "/api/v1/auth/withdraw",
+		Body:   nil,
+	}
+	recorder := testutil.ExecuteRequest(t, router, request)
+
+	// Then: Verify response
+	assert.Equal(t, http.StatusOK, recorder.Code)
+
+	var response sharedHttp.MessageResponse
+	testutil.ParseResponse(t, recorder, &response)
+	assert.Equal(t, "회원 탈퇴를 완료했습니다.\n 함께 기도해 주셔 감사합니다.", response.Message)
+
+	// Verify member is deleted from database
+	memberRepo := member.NewMemberRepository()
+	memberService := member.NewMemberService(memberRepo)
+	exists, err := memberService.ExistsByEmail(context.Background(), db, testMember.Email)
+	require.NoError(t, err)
+	assert.False(t, exists, "Member should be deleted from database")
+}
+
+func TestWithdraw_Unauthenticated(t *testing.T) {
+	// Given: Setup test environment without authentication
+	authHandler, _ := setupTestEnvironment(t)
+	router := testutil.SetupTestRouter() // No authentication
+	router.DELETE("/api/v1/auth/withdraw", authHandler.Withdraw)
+
+	// When: Execute withdraw request without auth
+	request := testutil.TestRequest{
+		Method: http.MethodDelete,
+		URL:    "/api/v1/auth/withdraw",
+		Body:   nil,
+	}
+	recorder := testutil.ExecuteRequest(t, router, request)
+
+	// Then: Verify unauthorized error
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+
+	var errorResponse sharedError.ErrorResponse
+	testutil.ParseResponse(t, recorder, &errorResponse)
+	assert.Equal(t, "AUTH-000", errorResponse.Code)
+	assert.Equal(t, "로그인을 해주세요.", errorResponse.Message)
+}
+
+func TestWithdraw_NonexistentMember(t *testing.T) {
+	// Given: Setup test environment with non-existent member ID
+	authHandler, _ := setupTestEnvironment(t)
+
+	nonexistentMemberID := int64(99999)
+	router := testutil.SetupAuthenticatedRouter(nonexistentMemberID)
+	router.DELETE("/api/v1/auth/withdraw", authHandler.Withdraw)
+
+	// When: Execute withdraw request
+	request := testutil.TestRequest{
+		Method: http.MethodDelete,
+		URL:    "/api/v1/auth/withdraw",
+		Body:   nil,
+	}
+	recorder := testutil.ExecuteRequest(t, router, request)
+
+	// Then: Verify not found error
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
+
+	var errorResponse sharedError.ErrorResponse
+	testutil.ParseResponse(t, recorder, &errorResponse)
+	assert.Equal(t, "MEMBER-001", errorResponse.Code)
+}
+
+func TestWithdraw_AlreadyWithdrawn(t *testing.T) {
+	// Given: Setup test environment
+	authHandler, db := setupTestEnvironmentWithDB(t)
+
+	// Create and withdraw member
+	testMember := testutil.CreateTestMember(t, db)
+	router := testutil.SetupAuthenticatedRouter(int64(testMember.ID))
+	router.DELETE("/api/v1/auth/withdraw", authHandler.Withdraw)
+
+	// First withdrawal
+	firstRequest := testutil.TestRequest{
+		Method: http.MethodDelete,
+		URL:    "/api/v1/auth/withdraw",
+		Body:   nil,
+	}
+	firstRecorder := testutil.ExecuteRequest(t, router, firstRequest)
+	require.Equal(t, http.StatusOK, firstRecorder.Code)
+
+	// When: Try to withdraw again
+	secondRequest := testutil.TestRequest{
+		Method: http.MethodDelete,
+		URL:    "/api/v1/auth/withdraw",
+		Body:   nil,
+	}
+	secondRecorder := testutil.ExecuteRequest(t, router, secondRequest)
+
+	// Then: Verify not found error
+	assert.Equal(t, http.StatusNotFound, secondRecorder.Code)
+
+	var errorResponse sharedError.ErrorResponse
+	testutil.ParseResponse(t, secondRecorder, &errorResponse)
+	assert.Equal(t, "MEMBER-001", errorResponse.Code)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	JWT      JWTConfig
 	CORS     CORSConfig
 	Server   ServerConfig
+	SMTP     SMTPConfig
 }
 
 type AppConfig struct {
@@ -60,6 +61,14 @@ type ServerConfig struct {
 	GracefulTimeout time.Duration
 }
 
+type SMTPConfig struct {
+	Host     string
+	Port     int
+	Username string
+	Password string
+	From     string
+}
+
 func Load(env string) (*Config, error) {
 	if err := loadEnvFile(env); err != nil {
 		return nil, fmt.Errorf("환경 변수 로드 실패: %w", err)
@@ -100,6 +109,13 @@ func Load(env string) (*Config, error) {
 			WriteTimeout:    getEnvAsDuration("SERVER_WRITE_TIMEOUT", "15s"),
 			IdleTimeout:     getEnvAsDuration("SERVER_IDLE_TIMEOUT", "60s"),
 			GracefulTimeout: getEnvAsDuration("GRACEFUL_TIMEOUT", "30s"),
+		},
+		SMTP: SMTPConfig{
+			Host:     getEnv("SMTP_HOST", ""),
+			Port:     getEnvAsInt("SMTP_PORT", 587),
+			Username: getEnv("SMTP_USERNAME", ""),
+			Password: getEnv("SMTP_PASSWORD", ""),
+			From:     getEnv("SMTP_FROM", ""),
 		},
 	}
 

--- a/internal/member/repository.go
+++ b/internal/member/repository.go
@@ -70,3 +70,15 @@ func (m *MemberRepository) FindByID(ctx context.Context, db *gorm.DB, ID int64) 
 	}
 	return &member, nil
 }
+
+// Delete - 회원 삭제
+func (m *MemberRepository) Delete(ctx context.Context, db *gorm.DB, memberID int64) error {
+	result := db.WithContext(ctx).Delete(&model.Member{}, memberID)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}

--- a/internal/member/service.go
+++ b/internal/member/service.go
@@ -92,3 +92,16 @@ func (s *MemberService) CreateMember(ctx context.Context, db *gorm.DB, member *m
 
 	return nil
 }
+
+// DeleteMember - 회원 삭제
+func (s *MemberService) DeleteMember(ctx context.Context, db *gorm.DB, memberID int64) error {
+	err := s.memberRepository.Delete(ctx, db, memberID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("회원을 찾을 수 없습니다: %w", ErrMemberNotFound)
+		}
+		return fmt.Errorf("회원 삭제 실패: %w", err)
+	}
+
+	return nil
+}

--- a/internal/model/refresh_token.go
+++ b/internal/model/refresh_token.go
@@ -1,0 +1,34 @@
+package model
+
+import "time"
+
+// RefreshToken represents a refresh token stored in the database
+// Each member can have only one refresh token at a time
+type RefreshToken struct {
+	BaseEntity
+	ID        int64     `gorm:"column:id;primaryKey;autoIncrement"`
+	MemberID  int64     `gorm:"column:member_id;not null;uniqueIndex:idx_refresh_token_member_id"`
+	Token     string    `gorm:"column:token;type:VARCHAR2(512);not null"`
+	ExpiredAt time.Time `gorm:"column:expired_time;not null"`
+
+	Member *Member `gorm:"foreignKey:MemberID;references:ID;constraint:OnDelete:CASCADE"` // Member 엔티티 참조
+}
+
+// TableName specifies the table name for RefreshToken
+func (*RefreshToken) TableName() string {
+	return "refresh_token"
+}
+
+// IsExpired checks if the refresh token has expired
+func (rt *RefreshToken) IsExpired() bool {
+	return time.Now().After(rt.ExpiredAt)
+}
+
+// NewRefreshToken creates a new RefreshToken instance
+func NewRefreshToken(memberID int64, token string, expiresAt time.Time) *RefreshToken {
+	return &RefreshToken{
+		MemberID:  memberID,
+		Token:     token,
+		ExpiredAt: expiresAt,
+	}
+}

--- a/internal/prayer/test_helpers_test.go
+++ b/internal/prayer/test_helpers_test.go
@@ -26,7 +26,7 @@ func setupTestEnvironment(t *testing.T) (*prayer.PrayerHandler, *gorm.DB, int64)
 	// Setup room dependencies (needed for validation)
 	roomRepo := room.NewRoomRepository()
 	memberRoomRepo := room.NewMemberRoomRepository()
-	memberRepo := testutil.NewMemberRepository(db)
+	memberRepo := testutil.NewMemberRepository()
 	memberService := testutil.NewMemberService(memberRepo)
 	roomService := room.NewRoomService(roomRepo, memberRoomRepo, memberService)
 

--- a/internal/room/create_room_api_test.go
+++ b/internal/room/create_room_api_test.go
@@ -11,37 +11,7 @@ import (
 	sharedHttp "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/http"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/testutil"
 	"github.com/stretchr/testify/assert"
-	"gorm.io/gorm"
 )
-
-// setupTestEnvironment creates all dependencies needed for room handler tests
-// Returns the handler, database, and a test member
-func setupTestEnvironment(t *testing.T) (*room.RoomHandler, *gorm.DB, int64) {
-	t.Helper()
-
-	// Setup test database
-	db := testutil.SetupTestDB(t)
-	t.Cleanup(func() {
-		testutil.CleanupTestDB(t, db)
-	})
-
-	// Create a test member for authenticated requests
-	testMember := testutil.CreateTestMember(t, db)
-
-	// Setup dependencies - need to import member package
-	roomRepo := room.NewRoomRepository()
-	memberRoomRepo := room.NewMemberRoomRepository()
-
-	// Create member service for validation
-	memberRepo := testutil.NewMemberRepository(db)
-	memberService := testutil.NewMemberService(memberRepo)
-
-	roomService := room.NewRoomService(roomRepo, memberRoomRepo, memberService)
-	roomUseCase := room.NewRoomUseCase(db, roomService)
-	roomHandler := room.NewRoomHandler(roomUseCase)
-
-	return roomHandler, db, int64(testMember.ID)
-}
 
 func TestCreateRoom_Success(t *testing.T) {
 	// Given: Setup test environment

--- a/internal/room/fetch_room_members_api_test.go
+++ b/internal/room/fetch_room_members_api_test.go
@@ -1,43 +1,19 @@
-package room
+package room_test
 
 import (
 	"fmt"
 	"net/http"
 	"testing"
 
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/room"
 	sharedError "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/error"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/testutil"
 	"github.com/stretchr/testify/assert"
-	"gorm.io/gorm"
 )
-
-func setupFetchRoomMembersTestEnvironment(t *testing.T) (*RoomHandler, *gorm.DB, int64) {
-	t.Helper()
-
-	db := testutil.SetupTestDB(t)
-
-	// Create repositories
-	roomRepo := NewRoomRepository()
-	memberRoomRepo := NewMemberRoomRepository()
-	memberRepo := testutil.NewMemberRepository(db)
-
-	// Create member service for validation
-	memberService := testutil.NewMemberService(memberRepo)
-
-	// Create room service and handler
-	roomService := NewRoomService(roomRepo, memberRoomRepo, memberService)
-	roomUseCase := NewRoomUseCase(db, roomService)
-	roomHandler := NewRoomHandler(roomUseCase)
-
-	// Create test member
-	testMember := testutil.CreateTestMember(t, db)
-
-	return roomHandler, db, int64(testMember.ID)
-}
 
 func TestFetchRoomMembers_Success(t *testing.T) {
 	// Given: Setup test environment
-	roomHandler, db, ownerID := setupFetchRoomMembersTestEnvironment(t)
+	roomHandler, db, ownerID := setupTestEnvironment(t)
 	router := testutil.SetupAuthenticatedRouter(ownerID)
 	router.GET("/api/v1/rooms/:roomId/members", roomHandler.FetchRoomMembers)
 
@@ -60,7 +36,7 @@ func TestFetchRoomMembers_Success(t *testing.T) {
 	// Then: Verify response
 	assert.Equal(t, http.StatusOK, recorder.Code)
 
-	var response FetchRoomMemberResponse
+	var response room.FetchRoomMemberResponse
 	testutil.ParseResponse(t, recorder, &response)
 
 	// Verify member count
@@ -92,7 +68,7 @@ func TestFetchRoomMembers_Success(t *testing.T) {
 
 func TestFetchRoomMembers_InvalidRoomID(t *testing.T) {
 	// Given: Setup test environment
-	roomHandler, _, ownerID := setupFetchRoomMembersTestEnvironment(t)
+	roomHandler, _, ownerID := setupTestEnvironment(t)
 	router := testutil.SetupAuthenticatedRouter(ownerID)
 	router.GET("/api/v1/rooms/:roomId/members", roomHandler.FetchRoomMembers)
 
@@ -136,7 +112,7 @@ func TestFetchRoomMembers_InvalidRoomID(t *testing.T) {
 
 func TestFetchRoomMembers_NonexistentRoom(t *testing.T) {
 	// Given: Setup test environment
-	roomHandler, _, ownerID := setupFetchRoomMembersTestEnvironment(t)
+	roomHandler, _, ownerID := setupTestEnvironment(t)
 	router := testutil.SetupAuthenticatedRouter(ownerID)
 	router.GET("/api/v1/rooms/:roomId/members", roomHandler.FetchRoomMembers)
 
@@ -162,7 +138,7 @@ func TestFetchRoomMembers_NonexistentRoom(t *testing.T) {
 
 func TestFetchRoomMembers_NotMemberOfRoom(t *testing.T) {
 	// Given: Setup test environment
-	roomHandler, db, ownerID := setupFetchRoomMembersTestEnvironment(t)
+	roomHandler, db, ownerID := setupTestEnvironment(t)
 
 	// Create another member who is not part of the room
 	otherMember := testutil.CreateTestMemberWithIndex(t, db, 1)
@@ -192,7 +168,7 @@ func TestFetchRoomMembers_NotMemberOfRoom(t *testing.T) {
 
 func TestFetchRoomMembers_EmptyRoom(t *testing.T) {
 	// Given: Setup test environment with empty database
-	roomHandler, db, ownerID := setupFetchRoomMembersTestEnvironment(t)
+	roomHandler, db, ownerID := setupTestEnvironment(t)
 	router := testutil.SetupAuthenticatedRouter(ownerID)
 	router.GET("/api/v1/rooms/:roomId/members", roomHandler.FetchRoomMembers)
 
@@ -210,7 +186,7 @@ func TestFetchRoomMembers_EmptyRoom(t *testing.T) {
 	// Then: Verify response
 	assert.Equal(t, http.StatusOK, recorder.Code)
 
-	var response FetchRoomMemberResponse
+	var response room.FetchRoomMemberResponse
 	testutil.ParseResponse(t, recorder, &response)
 
 	// Verify only owner is in the room

--- a/internal/room/repository.go
+++ b/internal/room/repository.go
@@ -37,13 +37,13 @@ func (r *RoomRepository) FindRoomInfosByMemberIDInitial(ctx context.Context, db 
 			room.id,
 			room.name,
 			room.description,
-			mr.created_at as joined_time,
+			mr.created_time as joined_time,
 			mr.is_notification,
 			0 as member_count
 		`).
 		Joins("JOIN room ON mr.room_id = room.id").
 		Where("mr.member_id = ?", memberID).
-		Order("mr.created_at DESC").
+		Order("mr.created_time DESC").
 		Limit(limit).
 		Scan(&results).Error
 
@@ -64,13 +64,13 @@ func (r *RoomRepository) FindRoomInfosByMemberIDAfter(ctx context.Context, db *g
 			room.id,
 			room.name,
 			room.description,
-			mr.created_at as joined_time,
+			mr.created_time as joined_time,
 			mr.is_notification,
 			0 as member_count
 		`).
 		Joins("JOIN room ON mr.room_id = room.id").
-		Where("mr.member_id = ? AND mr.created_at < ?", memberID, after).
-		Order("mr.created_at DESC").
+		Where("mr.member_id = ? AND mr.created_time < ?", memberID, after).
+		Order("mr.created_time DESC").
 		Limit(limit).
 		Scan(&results).Error
 

--- a/internal/room/test_helpers_test.go
+++ b/internal/room/test_helpers_test.go
@@ -1,0 +1,38 @@
+package room_test
+
+import (
+	"testing"
+
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/room"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/testutil"
+	"gorm.io/gorm"
+)
+
+// setupTestEnvironment creates all dependencies needed for room handler tests
+// Returns the handler, database, and a test member ID
+func setupTestEnvironment(t *testing.T) (*room.RoomHandler, *gorm.DB, int64) {
+	t.Helper()
+
+	// Setup test database
+	db := testutil.SetupTestDB(t)
+	t.Cleanup(func() {
+		testutil.CleanupTestDB(t, db)
+	})
+
+	// Create a test member for authenticated requests
+	testMember := testutil.CreateTestMember(t, db)
+
+	// Setup dependencies
+	roomRepo := room.NewRoomRepository()
+	memberRoomRepo := room.NewMemberRoomRepository()
+
+	// Create member service for validation
+	memberRepo := testutil.NewMemberRepository(db)
+	memberService := testutil.NewMemberService(memberRepo)
+
+	roomService := room.NewRoomService(roomRepo, memberRoomRepo, memberService)
+	roomUseCase := room.NewRoomUseCase(db, roomService)
+	roomHandler := room.NewRoomHandler(roomUseCase)
+
+	return roomHandler, db, int64(testMember.ID)
+}

--- a/internal/room/test_helpers_test.go
+++ b/internal/room/test_helpers_test.go
@@ -27,7 +27,7 @@ func setupTestEnvironment(t *testing.T) (*room.RoomHandler, *gorm.DB, int64) {
 	memberRoomRepo := room.NewMemberRoomRepository()
 
 	// Create member service for validation
-	memberRepo := testutil.NewMemberRepository(db)
+	memberRepo := testutil.NewMemberRepository()
 	memberService := testutil.NewMemberService(memberRepo)
 
 	roomService := room.NewRoomService(roomRepo, memberRoomRepo, memberService)

--- a/internal/router/routes.go
+++ b/internal/router/routes.go
@@ -62,6 +62,7 @@ func Setup(router *gin.Engine, cfg *config.Config, db *database.DB) {
 		authV1.POST("/login", authHandler.Login)
 		authV1.POST("/otp/email", authHandler.RequestEmailOTP)
 		authV1.POST("/otp/email/verification", authHandler.VerifyEmailOTP)
+		authV1.DELETE("/withdraw", middleware.JWT(cfg), authHandler.Withdraw)
 	}
 
 	memberV1 := router.Group("/api/v1/members")

--- a/internal/router/routes.go
+++ b/internal/router/routes.go
@@ -1,7 +1,10 @@
 package router
 
 import (
+	"time"
+
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/auth"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/auth/otp"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/config"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/member"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/meta"
@@ -25,6 +28,12 @@ func Setup(router *gin.Engine, cfg *config.Config, db *database.DB) {
 	memberRoomRepository := room.NewMemberRoomRepository()
 	prayerRepository := prayer.NewPrayerRepository()
 
+	// OTP dependencies
+	otpCache := otp.NewInMemoryCache()
+	otpSender := otp.NewSMTPSender(cfg.SMTP)
+	otpGenerator := otp.NewNumericGenerator(6)
+	otpService := otp.NewService(otpCache, otpSender, otpGenerator, 3*time.Minute) // 3분 TTL
+
 	// shared services
 	tokenManager := token.NewJWTManager(cfg)
 
@@ -36,7 +45,7 @@ func Setup(router *gin.Engine, cfg *config.Config, db *database.DB) {
 
 	// usecase
 	memberUseCase := member.NewMemberUseCase(db.DB, memberService)
-	authUseCase := auth.NewAuthUseCase(db.DB, memberService, tokenManager, authService)
+	authUseCase := auth.NewAuthUseCase(db.DB, memberService, tokenManager, authService, otpService)
 	roomUseCase := room.NewRoomUseCase(db.DB, roomService)
 	prayerUseCase := prayer.NewPrayerUseCase(db.DB, prayerService, roomService, memberService)
 
@@ -51,6 +60,7 @@ func Setup(router *gin.Engine, cfg *config.Config, db *database.DB) {
 	{
 		authV1.POST("/signup", authHandler.Signup)
 		authV1.POST("/login", authHandler.Login)
+		authV1.POST("/otp/email", authHandler.RequestEmailOTP)
 	}
 
 	memberV1 := router.Group("/api/v1/members")

--- a/internal/router/routes.go
+++ b/internal/router/routes.go
@@ -65,6 +65,7 @@ func Setup(router *gin.Engine, cfg *config.Config, db *database.DB) {
 		authV1.POST("/otp/email", authHandler.RequestEmailOTP)
 		authV1.POST("/otp/email/verification", authHandler.VerifyEmailOTP)
 		authV1.POST("/reissue-token", authHandler.ReissueToken)
+		authV1.POST("/logout", middleware.JWT(cfg), authHandler.Logout)
 		authV1.DELETE("/withdraw", middleware.JWT(cfg), authHandler.Withdraw)
 	}
 

--- a/internal/router/routes.go
+++ b/internal/router/routes.go
@@ -61,6 +61,7 @@ func Setup(router *gin.Engine, cfg *config.Config, db *database.DB) {
 		authV1.POST("/signup", authHandler.Signup)
 		authV1.POST("/login", authHandler.Login)
 		authV1.POST("/otp/email", authHandler.RequestEmailOTP)
+		authV1.POST("/otp/email/verification", authHandler.VerifyEmailOTP)
 	}
 
 	memberV1 := router.Group("/api/v1/members")

--- a/internal/router/routes.go
+++ b/internal/router/routes.go
@@ -27,6 +27,7 @@ func Setup(router *gin.Engine, cfg *config.Config, db *database.DB) {
 	roomRepository := room.NewRoomRepository()
 	memberRoomRepository := room.NewMemberRoomRepository()
 	prayerRepository := prayer.NewPrayerRepository()
+	refreshTokenRepository := auth.NewRefreshTokenRepository()
 
 	// OTP dependencies
 	otpCache := otp.NewInMemoryCache()
@@ -40,12 +41,13 @@ func Setup(router *gin.Engine, cfg *config.Config, db *database.DB) {
 	// service
 	memberService := member.NewMemberService(memberRepo)
 	authService := auth.NewAuthService()
+	refreshTokenService := auth.NewRefreshTokenService(refreshTokenRepository)
 	roomService := room.NewRoomService(roomRepository, memberRoomRepository, memberService)
 	prayerService := prayer.NewPrayerService(prayerRepository)
 
 	// usecase
 	memberUseCase := member.NewMemberUseCase(db.DB, memberService)
-	authUseCase := auth.NewAuthUseCase(db.DB, memberService, tokenManager, authService, otpService)
+	authUseCase := auth.NewAuthUseCase(db.DB, memberService, tokenManager, authService, otpService, refreshTokenService)
 	roomUseCase := room.NewRoomUseCase(db.DB, roomService)
 	prayerUseCase := prayer.NewPrayerUseCase(db.DB, prayerService, roomService, memberService)
 
@@ -62,6 +64,7 @@ func Setup(router *gin.Engine, cfg *config.Config, db *database.DB) {
 		authV1.POST("/login", authHandler.Login)
 		authV1.POST("/otp/email", authHandler.RequestEmailOTP)
 		authV1.POST("/otp/email/verification", authHandler.VerifyEmailOTP)
+		authV1.POST("/reissue-token", authHandler.ReissueToken)
 		authV1.DELETE("/withdraw", middleware.JWT(cfg), authHandler.Withdraw)
 	}
 

--- a/internal/shared/database/migration.go
+++ b/internal/shared/database/migration.go
@@ -33,7 +33,7 @@ func Migrate(db *gorm.DB, cfg *config.Config) error {
 
 	// Order matters: drop in reverse dependency order (FK constraints)
 	// member_room → room, member (FK 참조하는 테이블 먼저)
-	tableNames := []string{"member_room", "room", "member"}
+	tableNames := []string{"member_room", "room", "refresh_token", "member"}
 
 	for _, tableName := range tableNames {
 		// Check if table exists (Oracle)
@@ -72,7 +72,8 @@ func runAutoMigrate(db *gorm.DB) error {
 		&model.Member{},
 
 		// Dependent tables (with foreign keys)
-		&model.MemberRoom{}, // FK: room_id, member_id
+		&model.RefreshToken{}, // FK: member_id
+		&model.MemberRoom{},   // FK: room_id, member_id
 		&model.PrayerTitle{},
 		&model.PrayerContent{},
 	}

--- a/internal/shared/testutil/database.go
+++ b/internal/shared/testutil/database.go
@@ -27,6 +27,7 @@ func SetupTestDB(t *testing.T) *gorm.DB {
 		&model.MemberRoom{},
 		&model.Room{},
 		&model.Member{},
+		&model.RefreshToken{},
 		&model.PrayerTitle{},
 		&model.PrayerContent{},
 		// Add other models here as needed

--- a/internal/shared/testutil/member.go
+++ b/internal/shared/testutil/member.go
@@ -2,9 +2,10 @@ package testutil
 
 import (
 	"fmt"
-	"github.com/changhyeonkim/pray-together/go-api-server/internal/model"
 	"strconv"
 	"testing"
+
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/model"
 
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/member"
 	"golang.org/x/crypto/bcrypt"
@@ -54,7 +55,7 @@ func CreateTestMemberWithIndex(t *testing.T, db *gorm.DB, index int) *model.Memb
 }
 
 // NewMemberRepository creates a new MemberRepository for testing
-func NewMemberRepository(db *gorm.DB) *member.MemberRepository {
+func NewMemberRepository() *member.MemberRepository {
 	return member.NewMemberRepository()
 }
 

--- a/internal/shared/testutil/otp.go
+++ b/internal/shared/testutil/otp.go
@@ -1,0 +1,30 @@
+package testutil
+
+import (
+	"time"
+
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/auth/otp"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/config"
+)
+
+// NewTestOTPService creates an OTP service for testing with mock SMTP sender
+func NewTestOTPService() (*otp.Service, *otp.SMTPSender) {
+	cache := otp.NewInMemoryCache()
+	mockSender := NewRealSMTPSender()
+	generator := otp.NewNumericGenerator(6)
+	service := otp.NewService(cache, nil, generator, 3*time.Minute)
+	return service, mockSender
+}
+
+// NewRealSMTPSender creates a real SMTP sender for integration tests
+// Only use this if you have a real SMTP server configured
+func NewRealSMTPSender() *otp.SMTPSender {
+	cfg := config.SMTPConfig{
+		Host:     "smtp.example.com",
+		Port:     587,
+		Username: "test@example.com",
+		Password: "password",
+		From:     "test@example.com",
+	}
+	return otp.NewSMTPSender(cfg)
+}

--- a/internal/shared/testutil/token.go
+++ b/internal/shared/testutil/token.go
@@ -1,6 +1,9 @@
 package testutil
 
 import (
+	"time"
+
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/config"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/token"
 )
 
@@ -9,6 +12,9 @@ type MockTokenManager struct {
 	GenerateAccessTokenFunc  func(memberID, email string) (string, error)
 	GenerateRefreshTokenFunc func(memberID, email string) (string, error)
 	ValidateTokenFunc        func(tokenString string) (*token.Claims, error)
+	ExtractMemberIDFunc      func(tokenString string) (int64, error)
+	ExtractExpirationFunc    func(tokenString string) (time.Time, error)
+	IsValidFunc              func(tokenString string) bool
 }
 
 func (m *MockTokenManager) GenerateAccessToken(memberID, email string) (string, error) {
@@ -32,10 +38,43 @@ func (m *MockTokenManager) ValidateToken(tokenString string) (*token.Claims, err
 	return nil, nil
 }
 
+func (m *MockTokenManager) ExtractMemberID(tokenString string) (int64, error) {
+	if m.ExtractMemberIDFunc != nil {
+		return m.ExtractMemberIDFunc(tokenString)
+	}
+	// Default: try to parse from token string, fallback to 1
+	if tokenString != "" {
+		// In tests, tokens might be real JWTs, so we could parse them
+		// For now, just return a sensible default
+		return 1, nil
+	}
+	return 1, nil
+}
+
+func (m *MockTokenManager) ExtractExpiration(tokenString string) (time.Time, error) {
+	if m.ExtractExpirationFunc != nil {
+		return m.ExtractExpirationFunc(tokenString)
+	}
+	return time.Now().Add(7 * 24 * time.Hour), nil
+}
+
+func (m *MockTokenManager) IsValid(tokenString string) bool {
+	if m.IsValidFunc != nil {
+		return m.IsValidFunc(tokenString)
+	}
+	return true
+}
+
 // Ensure MockTokenManager implements token.Manager
 var _ token.Manager = (*MockTokenManager)(nil)
 
 // NewMockTokenManager creates a new mock token manager with default behavior
 func NewMockTokenManager() *MockTokenManager {
 	return &MockTokenManager{}
+}
+
+// NewRealJWTManager creates a real JWT manager for integration tests
+// Use this when you need actual token generation/validation
+func NewRealJWTManager(cfg *config.Config) *token.JWTManager {
+	return token.NewJWTManager(cfg)
 }

--- a/internal/shared/token/errors.go
+++ b/internal/shared/token/errors.go
@@ -53,12 +53,12 @@ func init() {
 	sharedError.RegisterDomainErrorResponse(generateAccessToken, sharedError.ErrorResponse{
 		Status:  http.StatusInternalServerError,
 		Code:    "TOKEN-004",
-		Message: "액세스 토큰 생성에 실패했습니다.",
+		Message: "인증에 실패했습니다.",
 	})
 
 	sharedError.RegisterDomainErrorResponse(generateRefreshToken, sharedError.ErrorResponse{
 		Status:  http.StatusInternalServerError,
 		Code:    "TOKEN-005",
-		Message: "리프레시 토큰 생성에 실패했습니다.",
+		Message: "인증에 실패했습니다.",
 	})
 }

--- a/internal/shared/token/jwt_manager.go
+++ b/internal/shared/token/jwt_manager.go
@@ -3,6 +3,7 @@ package token
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/config"
@@ -27,6 +28,8 @@ type Manager interface {
 	GenerateAccessToken(memberID string, email string) (string, error)
 	GenerateRefreshToken(memerID string, email string) (string, error)
 	ValidateToken(tokenString string) (*Claims, error)
+	ExtractMemberID(tokenString string) (int64, error)
+	ExtractExpiration(tokenString string) (time.Time, error)
 }
 
 type JWTManager struct {
@@ -65,7 +68,7 @@ func (m *JWTManager) GenerateAccessToken(memberID, email string) (string, error)
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	signedToken, err := token.SignedString(m.secret)
 	if err != nil {
-		return "", fmt.Errorf("%w: %v", ErrGenerateAccessToken, err)
+		return "", fmt.Errorf("AccessToken 생성 실패 %w: %v", ErrGenerateAccessToken, err)
 	}
 	return signedToken, nil
 }
@@ -91,7 +94,7 @@ func (m *JWTManager) GenerateRefreshToken(memberID string, email string) (string
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	signedToken, err := token.SignedString(m.secret)
 	if err != nil {
-		return "", fmt.Errorf("%w: %v", ErrGenerateRefreshToken, err)
+		return "", fmt.Errorf("RefreshToken 생성 실패 %w: %v", ErrGenerateRefreshToken, err)
 	}
 	return signedToken, nil
 }
@@ -104,19 +107,60 @@ func (m *JWTManager) ValidateToken(tokenString string) (*Claims, error) {
 	})
 	if err != nil {
 		if errors.Is(err, jwt.ErrTokenExpired) {
-			return nil, fmt.Errorf("%w: %v", ErrExpiredToken, err)
+			return nil, fmt.Errorf("JWT 토큰 만료 %w : %v", ErrExpiredToken, err)
 		}
-		return nil, fmt.Errorf("%w: %v", ErrInvalidToken, err)
+		return nil, fmt.Errorf("JWT 검증 오류 %w : %v", ErrInvalidToken, err)
 	}
 
 	claims, ok := token.Claims.(*Claims)
 	if !ok {
-		return nil, ErrInvalidClaims
+		return nil, fmt.Errorf("JWT 페이로드 오류 %w", ErrInvalidClaims)
 	}
 
 	if !token.Valid {
-		return nil, ErrInvalidToken
+		return nil, fmt.Errorf("JWT 검증 오류 %w : %v", ErrInvalidToken, err)
 	}
 
 	return claims, nil
+}
+
+// ExtractMemberID extracts memberID from token without full validation
+// Used for reissue token flow where we need memberID before validation
+func (m *JWTManager) ExtractMemberID(tokenString string) (int64, error) {
+	parser := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
+
+	token, _, err := parser.ParseUnverified(tokenString, &Claims{})
+	if err != nil {
+		return 0, fmt.Errorf("JWT 토큰 파싱 오류 %w: %v", ErrInvalidToken, err)
+	}
+
+	claims, ok := token.Claims.(*Claims)
+	if !ok {
+		return 0, fmt.Errorf("JWT 페이로드 오류 %w", ErrInvalidClaims)
+	}
+
+	memberID, err := strconv.ParseInt(claims.MemberID, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("MemberID 변환 오류 %w: %v", ErrInvalidClaims, err)
+	}
+
+	return memberID, nil
+}
+
+// ExtractExpiration extracts expiration time from token without full validation
+// Used for storing refresh token expiration time
+func (m *JWTManager) ExtractExpiration(tokenString string) (time.Time, error) {
+	parser := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))
+
+	token, _, err := parser.ParseUnverified(tokenString, &Claims{})
+	if err != nil {
+		return time.Time{}, fmt.Errorf("JWT 토큰 파싱 오류 %w: %v", ErrInvalidToken, err)
+	}
+
+	claims, ok := token.Claims.(*Claims)
+	if !ok {
+		return time.Time{}, fmt.Errorf("JWT 페이로드 오류 %w", ErrInvalidClaims)
+	}
+
+	return time.Unix(claims.ExpiresAt, 0), nil
 }

--- a/templates/email/otp.html
+++ b/templates/email/otp.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Added for better mobile rendering -->
+    <title>인증번호 안내</title> <!-- Added Title -->
+</head>
+<body style="margin: 0; padding: 0; font-family: Arial, sans-serif; background-color: #f4f7f6;">
+<div
+        style="max-width: 600px; margin: 20px auto; background-color: #FFFFFF; border-radius: 8px; border: 1px solid #e0e0e0; overflow: hidden;">
+
+    <!-- Header -->
+    <div style="padding: 30px 20px; text-align: center; border-bottom: 1px solid #eeeeee;">
+        <h1 style="color: #003262; /* Secondary Color */ margin: 0; font-size: 24px; font-weight: bold;">
+            인증번호 안내</h1>
+    </div>
+
+    <!-- Content -->
+    <div
+            style="padding: 40px 30px; text-align: center; background-color: #FFFFFF; /* Primary Color */">
+        <p style="margin: 0 0 25px 0; font-size: 16px; color: #333333; line-height: 1.6;">
+            요청하신 인증번호를 보내드립니다.
+        </p>
+
+        <!-- Verification Code Block -->
+        <div
+                style="background-color: #eef2f9; /* Light blue/grey tint */ padding: 25px; border-radius: 6px; margin: 25px 0;">
+        <span
+                style="font-size: 36px; letter-spacing: 6px; font-weight: bold; color: #003262; /* Secondary Color */ display: inline-block; line-height: 1.2;">
+          {{.OTP}}
+        </span>
+        </div>
+
+        <p style="margin: 25px 0 10px 0; font-size: 14px; color: #555555;">
+            인증번호는 <strong style="color: #273F85; /* Third Color */">3분</strong> 동안 유효합니다.
+        </p>
+        <p style="margin: 0 0 10px 0; font-size: 14px; color: #555555;">
+            본인이 요청하지 않으셨다면 이 메일을 무시하셔도 됩니다.
+        </p>
+    </div>
+
+    <!-- Footer -->
+    <div
+            style="text-align: center; color: #888888; font-size: 12px; padding: 20px 30px; border-top: 1px solid #eeeeee; background-color: #f8f9fa;">
+        <p style="margin: 0;">본 메일은 발신 전용으로 회신되지 않습니다.</p>
+        <p style="margin: 10px 0 0 0; color: #003262;">© 기도함께</p>
+    </div>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
 📝 어떤 변경인가요?

  새로운 기능

  Auth API 4개 추가

  - POST /api/v1/auth/otp/email - 회원가입 이메일 OTP 발급
  - POST /api/v1/auth/otp/email/verification - 이메일 OTP 검증
  - POST /api/v1/auth/reissue-token - JWT Access/Refresh 토큰 재발급
  - DELETE /api/v1/auth/withdraw - 회원 탈퇴
  - DELETE /api/v1/auth/logout - 로그아웃 (Refresh Token 삭제)

  주요 추가/수정 항목

  Auth 도메인 - 새로운 파일

  - internal/auth/otp/ 패키지 전체 (cache, generator, service, smtp_sender, errors)
  - internal/auth/refresh_token_repository.go - Refresh Token 저장소
  - internal/auth/refresh_token_service.go - Refresh Token 비즈니스 로직
  - internal/model/refresh_token.go - Refresh Token 엔티티
  - templates/email/otp.html - OTP 이메일 HTML 템플릿

  Auth 도메인 - 수정된 파일

  - internal/auth/handler.go - 4개 API 엔드포인트 추가 (RequestEmailOTP, VerifyEmailOTP, Withdraw, Logout, ReissueToken)
  - internal/auth/usecase.go - 해당 유스케이스 로직 추가
  - internal/auth/dto.go - 요청/응답 DTO 추가
  - internal/auth/errors.go - 도메인 에러 추가

  테스트 코드

  - internal/auth/logout_api_test.go - 로그아웃 API 통합 테스트
  - internal/auth/reissue_token_api_test.go - 토큰 재발급 API 통합 테스트
  - internal/auth/withdraw_api_test.go - 회원 탈퇴 API 통합 테스트
  - internal/auth/test_helpers_test.go - Auth 테스트 헬퍼 함수
  - internal/auth/signup_api_test.go - 기존 회원가입 테스트 개선

  공용 모듈 확장

  - internal/config/config.go - SMTP 설정 추가 (Host, Port, Username, Password, From)
  - internal/member/repository.go - DeleteByID 메서드 추가
  - internal/member/service.go - DeleteMember 메서드 추가
  - internal/shared/token/jwt_manager.go - ExtractExpiration 메서드 추가
  - internal/shared/testutil/otp.go - OTP 테스트 유틸
  - internal/shared/testutil/token.go - 토큰 테스트 유틸 확장
  - internal/router/routes.go - Auth 라우트 추가

  버그 수정

  - internal/room/repository.go - 기도방 무한 스크롤 쿼리 수정 (ca0fb4c)

  테스트 개선

  - internal/prayer/test_helpers_test.go - 기도 테스트 헬퍼 리팩토링
  - internal/room/test_helpers_test.go - 방 테스트 헬퍼 추가
  - 여러 테스트에서 불필요한 DB 의존성 주입 제거

  🎯 변경의 목적은 무엇인가요?

  배경

  Java/Spring 백엔드의 Auth 도메인을 Go로 마이그레이션하면서 회원 인증 관련 전체 플로우를 구현해야 했습니다.

  목적

  - 회원가입 시 이메일 인증을 통한 본인 확인 프로세스 구축
  - JWT 기반 인증 시스템 완성 (Access Token + Refresh Token)
  - 회원 탈퇴 및 로그아웃 기능으로 사용자 계정 생명주기 관리
  - 기존 Java/Spring API 스펙과 100% 호환되는 Go API 제공

  🔧 어떻게 변경되었나요?

  새로운 파일

  OTP 시스템 (internal/auth/otp/)

  - cache.go - 인메모리 OTP 캐시 (이메일당 1개, TTL 적용)
  - generator.go - crypto/rand 기반 6자리 OTP 생성
  - service.go - OTP 발급/검증 비즈니스 로직
  - smtp_sender.go - HTML 이메일 발송 (net/smtp 사용)
  - errors.go - OTP 관련 에러 정의

  Refresh Token 시스템

  - refresh_token_repository.go - GORM 기반 저장소
  - refresh_token_service.go - 토큰 검증/저장/삭제 로직
  - internal/model/refresh_token.go - Refresh Token 엔티티

  테스트

  - logout_api_test.go - 로그아웃 시나리오 (정상, 미인증, 이미 로그아웃)
  - reissue_token_api_test.go - 토큰 재발급 시나리오 (정상, 만료, 불일치, 삭제된 회원)
  - withdraw_api_test.go - 회원 탈퇴 시나리오 (정상, 미인증, 이미 탈퇴)
  - test_helpers_test.go - Auth 테스트용 헬퍼 함수

  수정된 파일

  | 파일                                   | 변경 사항                                                                  |
  |--------------------------------------|------------------------------------------------------------------------|
  | internal/auth/handler.go             | RequestEmailOTP, VerifyEmailOTP, Withdraw, Logout, ReissueToken 핸들러 추가 |
  | internal/auth/usecase.go             | 5개 신규 유스케이스 구현 (OTP 발급/검증, 토큰 재발급, 탈퇴, 로그아웃)                           |
  | internal/auth/dto.go                 | EmailOtpRequest, VerifyOtpRequest, AuthTokenReissueRequest/Response 추가 |
  | internal/auth/errors.go              | ErrRefreshTokenNotFound, ErrRefreshTokenNotValid 등 추가                  |
  | internal/member/service.go           | DeleteMember 메서드 추가 (회원 탈퇴용)                                           |
  | internal/member/repository.go        | DeleteByID 메서드 추가                                                      |
  | internal/config/config.go            | SMTP 설정 5개 필드 추가                                                       |
  | internal/shared/token/jwt_manager.go | ExtractExpiration 메서드 추가 (Refresh Token 만료 시각 추출)                      |
  | internal/router/routes.go            | Auth 엔드포인트 5개 라우팅 추가                                                   |

  기술적 상세

  1. OTP 발급/검증 플로우

  발급 (RequestEmailOTP)

  1. 이메일 중복 체크 (MemberService)
  2. 6자리 OTP 생성 (crypto/rand)
  3. HTML 템플릿 로드 (templates/email/otp.html)
  4. SMTP로 이메일 발송
  5. 인메모리 캐시에 저장 (기존 OTP 덮어쓰기)

  검증 (VerifyEmailOTP)

  1. 캐시에서 OTP 조회
  2. 입력값과 비교
  3. 일치 시 캐시에서 즉시 삭제 (재사용 방지)
  4. 불일치 시 400 에러

  2. Refresh Token 저장 전략

  - 회원당 1개만 유지: 신규 로그인/재발급 시 기존 토큰 삭제
  - 검증 로직:
    a. DB에서 토큰 조회
    b. 만료 여부 확인 (ExpiredAt < Now)
    c. 요청 토큰과 저장된 토큰 일치 확인
    d. JWT 자체 유효성 검증
  - 실패 시 기존 토큰도 삭제 → 재로그인 강제

  3. 토큰 재발급 플로우 (ReissueToken)

  1. Refresh Token에서 memberID 추출
  2. RefreshTokenService.Validate (DB 조회 + 만료 확인 + 일치 여부)
  3. JWT 유효성 검증
  4. 기존 Refresh Token 삭제
  5. 회원 정보 조회
  6. 신규 Access Token + Refresh Token 발급
  7. 신규 Refresh Token 저장 (만료 시각 포함)

  4. 회원 탈퇴 플로우 (Withdraw)

  1. Access Token에서 memberID 추출
  2. MemberService.DeleteMember 호출
  3. Member 레코드 삭제 (GORM soft delete)
  4. 응답: "회원 탈퇴를 완료했습니다.\n 함께 기도해 주셔 감사합니다."

  5. 로그아웃 플로우 (Logout)

  1. Access Token에서 memberID 추출
  2. RefreshTokenService.Delete 호출
  3. Refresh Token 레코드 삭제
  4. 204 No Content 응답

  6. 버그 수정

  기도방 무한 스크롤 쿼리 수정 (ca0fb4c)

  - 문제: 커서 기반 페이지네이션 쿼리 오류
  - 해결: internal/room/repository.go의 WHERE 절 수정


  ⚠️ 특이 사항

  🔒 보안

  OTP 시스템

  - crypto/rand 기반 SecureRandom으로 6자리 OTP 생성
  - 인메모리 캐시 사용
  - 검증 성공 시 즉시 삭제하여 재사용 방지
  - 로그에 OTP 값 노출 안 됨

  Refresh Token

  - 회원당 1개만 유지 (중복 로그인 시 기존 토큰 무효화)
  - 검증 실패 시 기존 토큰도 삭제하여 보안 강화
  - JWT Secret은 환경변수로 관리

  이메일 발송

  - SMTP 인증 사용
  - App Password 사용 권장 (Gmail 2FA)

  기타 사항

  - OTP 유효 시간: 코드에서 하드코딩되지 않음 (캐시 TTL로 제어 가능)
  - Refresh Token 만료 시간: JWT에서 추출 (JwtManager.ExtractExpiration)
  - 회원 탈퇴는 soft delete (deleted_at 설정)

  ⚡ 성능

  OTP 시스템

  - 인메모리 캐시로 빠른 조회 (< 1ms)
  - 이메일 발송은 비동기 처리 미적용 (동기 발송)
    - 개선 필요 시 Goroutine + 큐 시스템 도입 권장

  Refresh Token

  - 회원당 1건만 유지하여 조회 성능 최적화
  - 인덱스: member_id (unique)

  JWT 검증

  - 서명 검증만 수행 (DB 조회 없음)
  - Refresh Token 재발급 시에만 DB 조회

  🐛 알려진 제한사항

  1. OTP 재발송 제한 없음
    - 현재 Rate Limiting 미구현
    - 프로덕션 배포 전 구현 필요
  2. 이메일 발송 동기 처리
    - SMTP 응답 대기로 인한 지연 가능
    - 비동기 처리 또는 큐 시스템 권장
  3. OTP 캐시 휘발성
    - 서버 재시작 시 모든 OTP 초기화
    - Redis 전환 권장
  4. Refresh Token 갱신 전략
    - 현재: 재발급 시마다 새 토큰 발행
    - Sliding Window 방식 미지원

  🔗 관련 이슈

  close #8
