### PR TITLE
Feature/10 member api

### DIFF
--- a/internal/member/dto.go
+++ b/internal/member/dto.go
@@ -11,3 +11,17 @@ type UpdateProfileRequest struct {
 	Name        *string `json:"name" binding:"omitempty,min=1,max=10"`
 	PhoneNumber *string `json:"phoneNumber" binding:"omitempty,phone"`
 }
+
+type SearchMemberRequest struct {
+	Name string `form:"name"`
+}
+
+type SearchMemberResponse struct {
+	Members []SearchMemberDTO `json:"members"`
+}
+
+type SearchMemberDTO struct {
+	ID                int64   `json:"id"`
+	Name              string  `json:"name"`
+	PhoneNumberSuffix *string `json:"phoneNumberSuffix"`
+}

--- a/internal/member/dto.go
+++ b/internal/member/dto.go
@@ -6,3 +6,8 @@ type FetchProfileResponse struct {
 	Email       string `json:"email"`
 	PhoneNumber string `json:"phoneNumber,omitempty"`
 }
+
+type UpdateProfileRequest struct {
+	Name        *string `json:"name" binding:"omitempty,min=1,max=10"`
+	PhoneNumber *string `json:"phoneNumber" binding:"omitempty,phone"`
+}

--- a/internal/member/handler.go
+++ b/internal/member/handler.go
@@ -47,3 +47,29 @@ func (h *MemberHandler) FetchProfile(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, response)
 }
+
+// UpdateProfile - 회원 프로필 수정 API
+func (h *MemberHandler) UpdateProfile(c *gin.Context) {
+	memberID, ok := sharedHttp.RequireMemberID(c)
+	if !ok {
+		return
+	}
+
+	var request UpdateProfileRequest
+	if !sharedHttp.BindJSON(c, &request) {
+		return
+	}
+
+	response, err := h.memberUseCase.UpdateProfile(c.Request.Context(), memberID, &request)
+	if err != nil {
+		if resp, ok := sharedError.ResolveDomainError(err); ok {
+			sharedHttp.RespondError(c, err, resp)
+			return
+		}
+
+		sharedHttp.RespondError(c, err, sharedError.InternalServerError)
+		return
+	}
+
+	c.JSON(http.StatusOK, response)
+}

--- a/internal/member/handler.go
+++ b/internal/member/handler.go
@@ -73,3 +73,29 @@ func (h *MemberHandler) UpdateProfile(c *gin.Context) {
 
 	c.JSON(http.StatusOK, response)
 }
+
+// SearchMembers - 회원 검색 API
+func (h *MemberHandler) SearchMembers(c *gin.Context) {
+	memberID, ok := sharedHttp.RequireMemberID(c)
+	if !ok {
+		return
+	}
+
+	var request SearchMemberRequest
+	if !sharedHttp.BindQuery(c, &request) {
+		return
+	}
+
+	response, err := h.memberUseCase.SearchMembers(c.Request.Context(), memberID, request.Name)
+	if err != nil {
+		if resp, ok := sharedError.ResolveDomainError(err); ok {
+			sharedHttp.RespondError(c, err, resp)
+			return
+		}
+
+		sharedHttp.RespondError(c, err, sharedError.InternalServerError)
+		return
+	}
+
+	c.JSON(http.StatusOK, response)
+}

--- a/internal/member/repository.go
+++ b/internal/member/repository.go
@@ -82,3 +82,25 @@ func (m *MemberRepository) Delete(ctx context.Context, db *gorm.DB, memberID int
 	}
 	return nil
 }
+
+// UpdateFields - 특정 필드 업데이트
+func (m *MemberRepository) UpdateFields(ctx context.Context, db *gorm.DB, memberID int64, updates map[string]any) error {
+	if len(updates) == 0 {
+		return nil
+	}
+
+	result := db.WithContext(ctx).
+		Model(&model.Member{}).
+		Where("id = ?", memberID).
+		Updates(updates)
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+
+	return nil
+}

--- a/internal/member/repository.go
+++ b/internal/member/repository.go
@@ -2,6 +2,8 @@ package member
 
 import (
 	"context"
+	"strings"
+
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/model"
 
 	"gorm.io/gorm"
@@ -9,6 +11,13 @@ import (
 
 // MemberRepository - Member 데이터 접근 계층
 type MemberRepository struct {
+}
+
+// SearchMemberResult - 회원 검색 결과 프로젝션
+type SearchMemberResult struct {
+	ID          int64
+	Name        string
+	PhoneNumber string
 }
 
 // NewMemberRepository - MemberRepository 생성자
@@ -103,4 +112,23 @@ func (m *MemberRepository) UpdateFields(ctx context.Context, db *gorm.DB, member
 	}
 
 	return nil
+}
+
+// SearchByName - 이름으로 회원 검색 (부분 일치)
+func (m *MemberRepository) SearchByName(ctx context.Context, db *gorm.DB, name string) ([]SearchMemberResult, error) {
+	var results []SearchMemberResult
+
+	query := db.WithContext(ctx).
+		Model(&model.Member{}).
+		Select("id, name, phone_number")
+
+	if trimmed := strings.TrimSpace(name); trimmed != "" {
+		query = query.Where("name LIKE ?", "%"+trimmed+"%")
+	}
+
+	if err := query.Order("id ASC").Find(&results).Error; err != nil {
+		return nil, err
+	}
+
+	return results, nil
 }

--- a/internal/member/search_members_api_test.go
+++ b/internal/member/search_members_api_test.go
@@ -1,0 +1,75 @@
+package member_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/member"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/model"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSearchMembers_ReturnsMatches(t *testing.T) {
+	memberHandler, db := setupMemberTestEnvironment(t)
+
+	m1 := testutil.CreateTestMemberWithIndex(t, db, 0)
+	m2 := testutil.CreateTestMemberWithIndex(t, db, 1)
+	m3 := testutil.CreateTestMemberWithIndex(t, db, 2)
+
+	// Customize member data for search scenario
+	db.Model(&model.Member{}).Where("id = ?", m1.ID).Updates(map[string]any{
+		"name":         "홍길동",
+		"phone_number": "010-1234-5678",
+	})
+	db.Model(&model.Member{}).Where("id = ?", m2.ID).Updates(map[string]any{
+		"name":         "홍길순",
+		"phone_number": "",
+	})
+	db.Model(&model.Member{}).Where("id = ?", m3.ID).Updates(map[string]any{
+		"name":         "김철수",
+		"phone_number": "010-0000-0000",
+	})
+
+	router := testutil.SetupAuthenticatedRouter(m1.ID)
+	router.GET("/api/v1/members/search", memberHandler.SearchMembers)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodGet,
+		URL:    "/api/v1/members/search?name=홍",
+	})
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+
+	var response member.SearchMemberResponse
+	testutil.ParseResponse(t, recorder, &response)
+	assert.Len(t, response.Members, 2)
+
+	resultMap := map[string]*string{}
+	for _, m := range response.Members {
+		resultMap[m.Name] = m.PhoneNumberSuffix
+	}
+
+	if suffix, ok := resultMap["홍길동"]; assert.True(t, ok) {
+		if assert.NotNil(t, suffix) {
+			assert.Equal(t, "5678", *suffix)
+		}
+	}
+
+	if suffix, ok := resultMap["홍길순"]; assert.True(t, ok) {
+		assert.Nil(t, suffix)
+	}
+}
+
+func TestSearchMembers_Unauthorized(t *testing.T) {
+	memberHandler, _ := setupMemberTestEnvironment(t)
+	router := testutil.SetupTestRouter()
+	router.GET("/api/v1/members/search", memberHandler.SearchMembers)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodGet,
+		URL:    "/api/v1/members/search?name=홍",
+	})
+
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+}

--- a/internal/member/service.go
+++ b/internal/member/service.go
@@ -129,3 +129,12 @@ func (s *MemberService) UpdateProfile(ctx context.Context, db *gorm.DB, memberID
 
 	return nil
 }
+
+// SearchMembers - 이름으로 회원 검색
+func (s *MemberService) SearchMembers(ctx context.Context, db *gorm.DB, name string) ([]SearchMemberResult, error) {
+	results, err := s.memberRepository.SearchByName(ctx, db, name)
+	if err != nil {
+		return nil, fmt.Errorf("회원 검색 실패: %w", err)
+	}
+	return results, nil
+}

--- a/internal/member/service.go
+++ b/internal/member/service.go
@@ -105,3 +105,27 @@ func (s *MemberService) DeleteMember(ctx context.Context, db *gorm.DB, memberID 
 
 	return nil
 }
+
+// UpdateProfile - 회원 프로필 업데이트
+func (s *MemberService) UpdateProfile(ctx context.Context, db *gorm.DB, memberID int64, name, phoneNumber *string) error {
+	updates := map[string]any{}
+	if name != nil {
+		updates["name"] = *name
+	}
+	if phoneNumber != nil {
+		updates["phone_number"] = *phoneNumber
+	}
+
+	if len(updates) == 0 {
+		return nil
+	}
+
+	if err := s.memberRepository.UpdateFields(ctx, db, memberID, updates); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("회원을 찾을 수 없습니다: %w", ErrMemberNotFound)
+		}
+		return fmt.Errorf("회원 정보 수정 실패: %w", err)
+	}
+
+	return nil
+}

--- a/internal/member/update_profile_api_test.go
+++ b/internal/member/update_profile_api_test.go
@@ -1,0 +1,118 @@
+package member_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/member"
+	sharedError "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/error"
+	sharedHttp "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/http"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func setupMemberTestEnvironment(t *testing.T) (*member.MemberHandler, *gorm.DB) {
+	t.Helper()
+
+	db := testutil.SetupTestDB(t)
+	t.Cleanup(func() {
+		testutil.CleanupTestDB(t, db)
+	})
+
+	memberRepo := member.NewMemberRepository()
+	memberService := member.NewMemberService(memberRepo)
+	memberUseCase := member.NewMemberUseCase(db, memberService)
+	memberHandler := member.NewMemberHandler(memberUseCase)
+
+	return memberHandler, db
+}
+
+func TestUpdateProfile_Success(t *testing.T) {
+	memberHandler, db := setupMemberTestEnvironment(t)
+	createdMember := testutil.CreateTestMember(t, db)
+
+	router := testutil.SetupAuthenticatedRouter(createdMember.ID)
+	router.PATCH("/api/v1/members/me", memberHandler.UpdateProfile)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodPatch,
+		URL:    "/api/v1/members/me",
+		Body: map[string]string{
+			"name":        "새이름",
+			"phoneNumber": "01099998888",
+		},
+	})
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+
+	var response sharedHttp.MessageResponse
+	testutil.ParseResponse(t, recorder, &response)
+	assert.Equal(t, "프로필을 변경했습니다.", response.Message)
+
+	memberRepo := member.NewMemberRepository()
+	updated, err := memberRepo.FindByID(context.Background(), db, createdMember.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "새이름", updated.Name)
+	assert.Equal(t, "010-9999-8888", updated.PhoneNumber)
+}
+
+func TestUpdateProfile_ValidationError(t *testing.T) {
+	memberHandler, db := setupMemberTestEnvironment(t)
+	createdMember := testutil.CreateTestMember(t, db)
+
+	router := testutil.SetupAuthenticatedRouter(createdMember.ID)
+	router.PATCH("/api/v1/members/me", memberHandler.UpdateProfile)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodPatch,
+		URL:    "/api/v1/members/me",
+		Body: map[string]string{
+			"name": "",
+		},
+	})
+
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+	var errorResponse sharedError.ErrorResponse
+	testutil.ParseResponse(t, recorder, &errorResponse)
+	assert.Equal(t, "ERROR-001", errorResponse.Code)
+}
+
+func TestUpdateProfile_Unauthorized(t *testing.T) {
+	memberHandler, _ := setupMemberTestEnvironment(t)
+	router := testutil.SetupTestRouter()
+	router.PATCH("/api/v1/members/me", memberHandler.UpdateProfile)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodPatch,
+		URL:    "/api/v1/members/me",
+	})
+
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+}
+
+func TestUpdateProfile_NotFound(t *testing.T) {
+	memberHandler, _ := setupMemberTestEnvironment(t)
+	const nonexistentID int64 = 99999
+
+	router := testutil.SetupAuthenticatedRouter(nonexistentID)
+	router.PATCH("/api/v1/members/me", memberHandler.UpdateProfile)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodPatch,
+		URL:    "/api/v1/members/me",
+		Body: map[string]string{
+			"name":        "테스트",
+			"phoneNumber": "01012345678",
+		},
+	})
+
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
+
+	var errorResponse sharedError.ErrorResponse
+	testutil.ParseResponse(t, recorder, &errorResponse)
+	assert.Equal(t, "MEMBER-001", errorResponse.Code)
+}

--- a/internal/member/usecase.go
+++ b/internal/member/usecase.go
@@ -2,10 +2,13 @@ package member
 
 import (
 	"context"
+	"strings"
+
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/model"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/database"
 	sharedDomain "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/domain"
 	sharedHttp "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/http"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/logger"
 	"gorm.io/gorm"
 )
 
@@ -56,4 +59,36 @@ func (u *MemberUseCase) UpdateProfile(ctx context.Context, memberID int64, reque
 	}
 
 	return &sharedHttp.MessageResponse{Message: "프로필을 변경했습니다."}, nil
+}
+
+// SearchMembers - 이름으로 회원 검색
+func (u *MemberUseCase) SearchMembers(ctx context.Context, memberID int64, name string) (*SearchMemberResponse, error) {
+	log := logger.FromContext(ctx)
+	log.Info("회원 검색 요청", "memberID", memberID, "keyword", name)
+
+	results, err := u.memberService.SearchMembers(ctx, u.db, name)
+	if err != nil {
+		return nil, err
+	}
+
+	members := make([]SearchMemberDTO, 0, len(results))
+	for _, result := range results {
+		var suffix *string
+		if strings.TrimSpace(result.PhoneNumber) != "" {
+			phone, err := sharedDomain.NewPhoneNumber(result.PhoneNumber)
+			if err != nil {
+				return nil, err
+			}
+			s := phone.GetSuffix()
+			suffix = &s
+		}
+
+		members = append(members, SearchMemberDTO{
+			ID:                result.ID,
+			Name:              result.Name,
+			PhoneNumberSuffix: suffix,
+		})
+	}
+
+	return &SearchMemberResponse{Members: members}, nil
 }

--- a/internal/member/usecase.go
+++ b/internal/member/usecase.go
@@ -3,7 +3,9 @@ package member
 import (
 	"context"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/model"
-
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/database"
+	sharedDomain "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/domain"
+	sharedHttp "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/http"
 	"gorm.io/gorm"
 )
 
@@ -33,4 +35,25 @@ func (u *MemberUseCase) GetMemberByEmail(ctx context.Context, email string) (*mo
 // Signup - 신규 회원 가입 유스케이스
 func (u *MemberUseCase) Signup(ctx context.Context, member *model.Member) error {
 	return u.memberService.CreateMember(ctx, u.db, member)
+}
+
+// UpdateProfile - 내 프로필 수정 유스케이스
+func (u *MemberUseCase) UpdateProfile(ctx context.Context, memberID int64, request *UpdateProfileRequest) (*sharedHttp.MessageResponse, error) {
+	var normalizedPhone *string
+	if request.PhoneNumber != nil {
+		phone, err := sharedDomain.NewPhoneNumber(*request.PhoneNumber)
+		if err != nil {
+			return nil, err
+		}
+		formatted := phone.String()
+		normalizedPhone = &formatted
+	}
+
+	if err := database.WithTransaction(ctx, u.db, func(tx *gorm.DB) error {
+		return u.memberService.UpdateProfile(ctx, tx, memberID, request.Name, normalizedPhone)
+	}); err != nil {
+		return nil, err
+	}
+
+	return &sharedHttp.MessageResponse{Message: "프로필을 변경했습니다."}, nil
 }

--- a/internal/router/routes.go
+++ b/internal/router/routes.go
@@ -74,6 +74,7 @@ func Setup(router *gin.Engine, cfg *config.Config, db *database.DB) {
 	{
 		memberV1.GET("/me", memberHandler.FetchProfile)
 		memberV1.PATCH("/me", memberHandler.UpdateProfile)
+		memberV1.GET("/search", memberHandler.SearchMembers)
 	}
 
 	roomV1 := router.Group("/api/v1/rooms")

--- a/internal/router/routes.go
+++ b/internal/router/routes.go
@@ -73,6 +73,7 @@ func Setup(router *gin.Engine, cfg *config.Config, db *database.DB) {
 	memberV1.Use(middleware.JWT(cfg))
 	{
 		memberV1.GET("/me", memberHandler.FetchProfile)
+		memberV1.PATCH("/me", memberHandler.UpdateProfile)
 	}
 
 	roomV1 := router.Group("/api/v1/rooms")


### PR DESCRIPTION
📝 어떤 변경인가요?

  새로운 기능

  Member API 2개 추가

  - PATCH /api/v1/members/me - 내 프로필 수정
  - GET /api/v1/members/search - 이름으로 회원 검색

  주요 추가/수정 항목

  Member 도메인 - 수정된 파일

  - internal/member/handler.go - UpdateProfile, SearchMembers 핸들러 추가
  - internal/member/usecase.go - UpdateProfile, SearchMembers 유스케이스 추가
  - internal/member/service.go - UpdateProfile, SearchMembers 서비스 메서드 추가
  - internal/member/repository.go - UpdateFields, SearchByName 메서드 추가
  - internal/member/dto.go - UpdateProfileRequest, SearchMemberRequest/Response DTO 추가
  - internal/router/routes.go - Member 엔드포인트 2개 라우팅 추가

  테스트 코드 - 새로운 파일

  - internal/member/update_profile_api_test.go - 프로필 수정 API 통합 테스트
  - internal/member/search_members_api_test.go - 회원 검색 API 통합 테스트

  🎯 변경의 목적은 무엇인가요?

  배경

  사용자가 자신의 프로필 정보를 수정하고, 기도방에 초대할 회원을 검색할 수 있는 기능이 필요했습니다.

  목적

  - 사용자가 이름과 전화번호를 자유롭게 수정할 수 있도록 프로필 관리 기능 제공
  - 기도방 초대 시 회원을 이름으로 빠르게 검색할 수 있는 기능 제공
  - 개인정보 보호를 위해 전화번호 뒷자리만 노출하여 회원 식별 지원

  🔧 어떻게 변경되었나요?

  수정된 파일

  | 파일                            | 변경 사항                                                       |
  |-------------------------------|-------------------------------------------------------------|
  | internal/member/handler.go    | UpdateProfile, SearchMembers 핸들러 추가                         |
  | internal/member/usecase.go    | UpdateProfile (트랜잭션 관리), SearchMembers (전화번호 뒷자리 처리) 추가     |
  | internal/member/service.go    | UpdateProfile (동적 필드 업데이트), SearchMembers (이름 검색) 추가        |
  | internal/member/repository.go | UpdateFields (부분 업데이트), SearchByName (LIKE 검색) 추가           |
  | internal/member/dto.go        | UpdateProfileRequest, SearchMember 관련 DTO 3개 추가             |
  | internal/router/routes.go     | PATCH /api/v1/members/me, GET /api/v1/members/search 라우트 추가 |

  기술적 상세

  1. 프로필 수정 플로우 (UpdateProfile)

  Request DTO 검증

  type UpdateProfileRequest struct {
      Name        *string `json:"name" binding:"omitempty,min=1,max=10"`
      PhoneNumber *string `json:"phoneNumber" binding:"omitempty,phone"`
  }
  - 두 필드 모두 optional (pointer 타입)
  - 이름: 1~10자 제한
  - 전화번호: 커스텀 phone validation 사용

  동적 필드 업데이트

  1. UseCase에서 전화번호 정규화 (010-1234-5678 형식)
  2. Service에서 변경된 필드만 map으로 수집
  3. Repository에서 GORM Updates로 동적 업데이트
  4. 트랜잭션 내에서 실행



  2. 회원 검색 플로우 (SearchMembers)

  검색 전략

  - 부분 일치: SQL LIKE '%keyword%'
  - 공백 무시: strings.TrimSpace로 전처리
  - 정렬: ID 오름차순
  - 전체 조회 지원: keyword가 비어있으면 모든 회원 반환

  전화번호 뒷자리 추출

  1. Repository에서 전체 전화번호 조회
  2. UseCase에서 PhoneNumber 도메인 객체로 변환
  3. GetSuffix() 메서드로 뒷자리 4자리만 추출
  4. 전화번호 없는 경우 null 반환

  Response DTO:
  type SearchMemberDTO struct {
      ID                int64   `json:"id"`
      Name              string  `json:"name"`
      PhoneNumberSuffix *string `json:"phoneNumberSuffix"`  // "1234" 형식
  }


 3. 전화번호 정규화

  PhoneNumber 도메인 객체 활용

  Input: "01012345678" or "010-1234-5678"
  ↓ NewPhoneNumber()
  Format: "010-1234-5678"
  ↓ GetSuffix()
  Suffix: "5678"

  ⚠️ 특이 사항

  🔒 보안

  개인정보 보호

  - 회원 검색 시 전화번호 뒷자리 4자리만 노출
  - 전체 전화번호는 노출하지 않음
  - 검색 기능은 인증된 사용자만 접근 가능 (JWT 미들웨어)

  프로필 수정 권한

  - 본인의 프로필만 수정 가능 (memberID 검증)
  - 다른 사용자의 프로필 수정 시도 시 자동 차단


  🔗 관련 이슈

  close #10