### PR TITLE
Feature/12 invitation api

### DIFF
--- a/MEMBER_API_SPECIFICATION.md
+++ b/MEMBER_API_SPECIFICATION.md
@@ -1,0 +1,377 @@
+# Member API Specification
+
+## Overview
+Member 도메인은 회원의 프로필 조회, 프로필 수정, 회원 검색 API를 제공합니다. 모든 엔드포인트는 `MemberController`(`src/main/java/site/praytogether/pray_together/domain/member/controller/MemberController.java`)를 통해 노출됩니다.
+
+## API 목록 (총 3개)
+
+### 프로필 관리 (2개)
+1. **GET /api/v1/members/me** - 내 프로필 조회
+2. **PATCH /api/v1/members/me** - 내 프로필 수정
+
+### 회원 검색 (1개)
+3. **GET /api/v1/members/search** - 이름으로 회원 검색
+
+---
+
+## Architecture Layers
+- **Handler/Controller**: HTTP 요청 수신, DTO 검증, 적절한 HTTP Status/Body 반환 (`MemberController`).
+- **UseCase/Application**: 도메인 서비스 조합 및 트랜잭션 관리 (`MemberApplicationService`).
+- **Domain/Service**: 회원 조회/수정 로직 처리 (`MemberService`).
+- **Repository/Infra**: 회원 데이터 영속화 및 조회 (`MemberRepository`).
+
+### Common Concepts
+
+#### Authentication Context
+- `@PrincipalId` 파라미터 리졸버가 SecurityContext의 `PrayTogetherPrincipal`에서 memberId를 추출합니다.
+- Access Token(JWT)은 Authorization 헤더(`Bearer <token>`)로 전달되며, 미인증 시 401 Unauthorized.
+
+#### PhoneNumber Value Object
+- 전화번호는 `PhoneNumber` 임베디드 타입으로 관리됩니다.
+- 하이픈 포함/미포함 입력을 허용하며, 저장 시 `XXX-XXXX-XXXX` 형식으로 정규화됩니다.
+- 검증 규칙: 한국 휴대폰 번호 형식 (010, 011, 016, 017, 018, 019 + 8자리 숫자).
+- `getSuffix()` 메서드로 뒤 4자리 추출이 가능합니다.
+
+#### Error Responses
+- 공통 유효성 검증 실패: 400 Bad Request (Bean Validation 메시지 그대로 반환).
+- `MemberNotFoundException`: 404 Not Found (`MEMBER-001`) - "회원 정보를 찾을 수 없습니다."
+
+---
+
+## API Endpoints
+
+### API 1. 내 프로필 조회 (Get My Profile)
+
+#### HTTP Request
+```
+GET /api/v1/members/me
+```
+
+#### Request Headers
+- `Authorization`: Bearer access token (required)
+
+#### Request Body
+- 없음
+
+#### Response
+**Status Code**: 200 OK
+
+**Body**:
+```json
+{
+  "id": "Long",
+  "name": "String",
+  "email": "String",
+  "phoneNumber": "String (nullable, format: XXX-XXXX-XXXX)"
+}
+```
+
+**Example**:
+```json
+{
+  "id": 123,
+  "name": "홍길동",
+  "email": "hong@example.com",
+  "phoneNumber": "010-1234-5678"
+}
+```
+
+#### Business Logic Flow
+**UseCase Layer** (`memberApplication.getProfile`):
+1. SecurityContext에서 추출된 `memberId`를 입력받습니다.
+2. `MemberService.fetchProfileById(memberId)` 호출로 회원 프로필 조회.
+   - 존재하지 않으면 `MemberNotFoundException`(404) 발생.
+3. `MemberProfile` 도메인 모델을 `MemberProfileResponse` DTO로 변환.
+4. 전화번호가 없는 경우 `phoneNumber` 필드는 `null`로 반환됩니다.
+
+#### Authorization Rules
+- Access Token 인증이 완료된 본인의 프로필만 조회할 수 있습니다.
+
+---
+
+### API 2. 내 프로필 수정 (Update My Profile)
+
+#### HTTP Request
+```
+PATCH /api/v1/members/me
+```
+
+#### Request Headers
+- `Authorization`: Bearer access token (required)
+- `Content-Type`: application/json
+
+#### Request Body
+```json
+{
+  "name": "String (optional, 1-10 characters)",
+  "phoneNumber": "String (optional, Korean phone format)"
+}
+```
+
+**Validation Rules:**
+- `name`: 선택적, 1자 이상 10자 이하 (`@Size`) - "이름은 1자 이상 10자 이하로 입력해 주세요."
+- `phoneNumber`: 선택적, 한국 휴대폰 번호 형식 (`@Pattern`) - "올바른 휴대폰 번호 형식이 아닙니다."
+  - 정규식: `^01[016789]-?\\d{4}-?\\d{4}$`
+  - 하이픈 포함 여부 무관 (예: `010-1234-5678` 또는 `01012345678`)
+
+**Note**:
+- `name`과 `phoneNumber`는 모두 선택적(optional) 필드입니다.
+- 수정하고 싶은 필드만 포함하면 됩니다.
+- 빈 JSON `{}`을 보내면 아무것도 수정되지 않습니다.
+
+#### Response
+**Status Code**: 200 OK
+
+**Body**:
+```json
+{
+  "message": "String"
+}
+```
+
+**Example**:
+```json
+{
+  "message": "프로필을 변경했습니다."
+}
+```
+
+#### Business Logic Flow
+**UseCase Layer** (`memberApplication.updateProfile`):
+1. SecurityContext에서 추출된 `memberId`와 `UpdateProfileRequest`를 입력받습니다.
+2. Request를 `UpdateProfileCommand` 도메인 커맨드로 변환.
+   - `phoneNumber` 문자열 → `PhoneNumber` Value Object 변환.
+   - 변환 과정에서 전화번호 형식 검증 및 정규화 수행.
+3. `MemberService.fetchById(memberId)`로 회원 엔티티 조회.
+   - 존재하지 않으면 `MemberNotFoundException`(404) 발생.
+4. **부분 업데이트 수행**:
+   - `command.getName() != null`이면 `member.updateName(name)` 호출.
+   - `command.getPhoneNumber() != null`이면 `member.updatePhoneNumber(phoneNumber)` 호출.
+5. JPA Dirty Checking으로 변경사항 자동 저장 (@Transactional).
+6. 성공 메시지 반환.
+
+#### Authorization Rules
+- Access Token 인증이 완료된 본인의 프로필만 수정할 수 있습니다.
+
+#### Domain Business Rules
+- 이름과 전화번호는 독립적으로 수정 가능합니다 (부분 업데이트).
+- 전화번호는 하이픈 포함/미포함 입력을 모두 허용하지만, 저장 시 `XXX-XXXX-XXXX` 형식으로 정규화됩니다.
+- 이메일과 비밀번호는 이 API로 수정할 수 없습니다.
+
+---
+
+### API 3. 회원 검색 (Search Members)
+
+#### HTTP Request
+```
+GET /api/v1/members/search
+```
+
+#### Query Parameters
+- `name`: String (required) - 검색할 회원 이름 (부분 일치)
+
+#### Request Headers
+- `Authorization`: Bearer access token (required)
+
+#### Response
+**Status Code**: 200 OK
+
+**Body**:
+```json
+{
+  "members": [
+    {
+      "id": "Long",
+      "name": "String",
+      "phoneNumberSuffix": "String (nullable, 전화번호 뒤 4자리)"
+    }
+  ]
+}
+```
+
+**Example**:
+```json
+{
+  "members": [
+    {
+      "id": 123,
+      "name": "홍길동",
+      "phoneNumberSuffix": "5678"
+    },
+    {
+      "id": 456,
+      "name": "홍길순",
+      "phoneNumberSuffix": null
+    }
+  ]
+}
+```
+
+**Note**:
+- 전화번호 전체가 아닌 뒤 4자리만 반환됩니다 (개인정보 보호).
+- 전화번호를 등록하지 않은 회원의 경우 `phoneNumberSuffix`는 `null`입니다.
+
+#### Business Logic Flow
+**UseCase Layer** (`memberApplication.searchMembers`):
+1. SecurityContext에서 추출된 `memberId` (인증 확인용)와 검색어 `searchName`을 입력받습니다.
+2. 검색어를 `SearchQueryMember` 도메인 모델로 변환.
+3. `MemberService.searchByName(queryMember)` 호출.
+   - Repository에서 `findByNameContaining(name)` 쿼리 실행 (부분 일치 검색).
+   - `SearchResultMember` 리스트 반환 (id, name, phoneNumber).
+4. `SearchResultMembers` 도메인 모델을 `SearchMemberResponse` DTO로 변환.
+   - `phoneNumber.getSuffix()`를 호출해 뒤 4자리만 추출.
+5. 검색 결과 리스트 반환.
+
+#### Authorization Rules
+- Access Token 인증이 완료된 회원만 검색할 수 있습니다.
+- 본인 외의 회원도 검색 가능합니다 (공개 검색).
+
+#### Search Behavior
+- **부분 일치 검색**: 입력한 이름이 포함된 모든 회원을 반환합니다.
+  - 예: "홍" 검색 시 "홍길동", "홍길순", "김홍철" 모두 반환.
+- **대소문자 구분**: 데이터베이스 설정에 따라 다를 수 있습니다.
+- **빈 검색어**: 현재 구현상 빈 문자열도 허용되며, 모든 회원을 반환할 수 있습니다.
+
+---
+
+## DTO Summary
+
+### Request DTOs
+
+#### UpdateProfileRequest
+```
+{
+  name: String (optional, @Size(min=1, max=10))
+  phoneNumber: String (optional, @Pattern(regexp="^01[016789]-?\\d{4}-?\\d{4}$"))
+}
+```
+
+**Validation Messages:**
+- name: "이름은 1자 이상 10자 이하로 입력해 주세요."
+- phoneNumber: "올바른 휴대폰 번호 형식이 아닙니다."
+
+### Response DTOs
+
+#### MemberProfileResponse
+```
+{
+  id: Long
+  name: String
+  email: String
+  phoneNumber: String (nullable)
+}
+```
+
+#### SearchMemberResponse
+```
+{
+  members: Array<SearchMemberDto>
+}
+
+SearchMemberDto:
+{
+  id: Long
+  name: String
+  phoneNumberSuffix: String (nullable, 뒤 4자리)
+}
+```
+
+#### MessageResponse
+```
+{
+  message: String
+}
+```
+
+---
+
+## Business Rules & Authorization
+
+### Authorization Rules
+1. **프로필 조회**: 인증된 본인만 자신의 프로필 조회 가능
+2. **프로필 수정**: 인증된 본인만 자신의 프로필 수정 가능
+3. **회원 검색**: 인증된 모든 회원이 다른 회원 검색 가능
+
+### Data Consistency Rules
+1. **이름 변경**: 1자 이상 10자 이하로 제한됩니다.
+2. **전화번호 변경**: 한국 휴대폰 번호 형식만 허용되며, 저장 시 `XXX-XXXX-XXXX` 형식으로 정규화됩니다.
+3. **이메일 불변**: 이메일은 회원 가입 후 변경할 수 없습니다 (고유 식별자).
+4. **부분 업데이트**: 프로필 수정 시 제공된 필드만 업데이트되며, 제공되지 않은 필드는 기존 값을 유지합니다.
+
+### Validation Rules
+1. **이름 검증**:
+   - 길이: 1자 이상 10자 이하
+   - 공백만으로는 구성될 수 없음
+2. **전화번호 검증**:
+   - 형식: `01[016789]-?\\d{4}-?\\d{4}` (하이픈 선택적)
+   - 정규화 후 형식: `XXX-XXXX-XXXX`
+   - Value Object 생성 시 자동 검증 및 정규화 수행
+3. **검색어 검증**:
+   - 현재 빈 문자열도 허용됨 (개선 가능)
+
+---
+
+## Implementation Notes for Go Migration
+
+### Handler Layer (Controller)
+- 동일한 엔드포인트/경로를 유지합니다.
+- Request validation: struct tags를 사용해 검증합니다.
+- JSON 바인딩 및 응답 직렬화를 처리합니다.
+- 인증 미들웨어에서 memberId를 추출해 handler에 전달합니다.
+
+### UseCase Layer (Application Service)
+- `MemberApplicationService`의 역할을 Go service로 분리합니다.
+- 트랜잭션 경계를 관리합니다 (@Transactional).
+- Request DTO → Domain Command 변환을 담당합니다.
+- 부분 업데이트 로직 (nil 체크)을 유지합니다.
+
+### Domain Layer (Service & Entity)
+- **PhoneNumber Value Object**:
+  - 전화번호 검증 및 정규화 로직을 구조체 메서드로 구현합니다.
+  - `Normalize()`, `Validate()`, `GetSuffix()` 메서드 제공.
+- **Member Entity**:
+  - `UpdateName()`, `UpdatePhoneNumber()` 메서드로 불변성을 보장합니다.
+- **부분 업데이트**: Optional 필드 처리를 위해 포인터 타입 사용을 고려합니다.
+
+### Repository Layer (Infrastructure)
+- 프로필 조회를 위한 projection 쿼리를 구현합니다.
+- 이름 검색: `LIKE '%name%'` 또는 full-text search를 사용합니다.
+- 전화번호 뒤 4자리 추출 로직을 repository 또는 mapper에서 처리합니다.
+
+### Cross-Cutting Concerns
+- **인증**: JWT 토큰 검증 및 memberId 추출.
+- **로깅**: API 시작/종료 로그 (`[API] 내 정보 조회 시작/종료`).
+- **에러 처리**: 일관된 에러 응답 포맷 유지.
+- **개인정보 보호**: 검색 시 전화번호 전체가 아닌 뒤 4자리만 노출.
+
+### Testing Considerations
+1. **프로필 조회**: 존재하지 않는 memberId로 조회 시 404 응답 확인.
+2. **프로필 수정**:
+   - 부분 업데이트 검증 (name만, phoneNumber만, 둘 다, 둘 다 없음).
+   - 전화번호 형식 검증 (하이픈 포함/미포함 모두 성공).
+   - 잘못된 전화번호 형식으로 400 응답 확인.
+3. **회원 검색**:
+   - 부분 일치 검색이 정상 작동하는지 확인.
+   - 전화번호 뒤 4자리만 반환되는지 확인.
+   - 전화번호가 없는 회원의 경우 null 처리 확인.
+4. **인증**: 토큰 없이 호출 시 401 응답 확인.
+
+---
+
+## Security & Privacy Considerations
+
+1. **개인정보 보호**:
+   - 회원 검색 시 전화번호 전체를 노출하지 않고 뒤 4자리만 반환합니다.
+   - 이메일은 검색 결과에 포함되지 않습니다.
+
+2. **접근 제어**:
+   - 프로필 조회/수정은 본인만 가능합니다.
+   - 회원 검색은 인증된 모든 사용자가 가능합니다.
+
+3. **데이터 검증**:
+   - 전화번호는 Value Object를 통해 도메인 레벨에서 검증됩니다.
+   - Controller 레벨의 Bean Validation과 이중 검증 구조를 가집니다.
+
+4. **Rate Limiting**:
+   - 현재 구현되어 있지 않으며, 외부 API Gateway나 미들웨어에서 처리해야 합니다.
+   - 특히 회원 검색 API는 남용 방지를 위해 rate limiting 적용을 권장합니다.

--- a/internal/invitation/dto.go
+++ b/internal/invitation/dto.go
@@ -7,10 +7,10 @@ type InviteMembersRequest struct {
 }
 
 // InvitationInfoScrollResponse represents the response of invitation list
-//type InvitationInfoScrollResponse struct {
-//	Invitations []InvitationInfo `json:"invitations"`
-//}
-//
+type InvitationInfoScrollResponse struct {
+	Invitations []InvitationInfo `json:"invitations"`
+}
+
 //// InvitationStatusUpdateRequest represents the request to update invitation status
 //type InvitationStatusUpdateRequest struct {
 //	Status string `json:"status" binding:"required,oneof=ACCEPTED REJECTED"`

--- a/internal/invitation/dto.go
+++ b/internal/invitation/dto.go
@@ -1,0 +1,17 @@
+package invitation
+
+// InviteMembersRequest represents the request to invite members to a room (V2)
+type InviteMembersRequest struct {
+	RoomID    int64   `json:"roomId" binding:"required,gt=0"`
+	MemberIDs []int64 `json:"memberIds" binding:"required,min=1,dive,gt=0"`
+}
+
+// InvitationInfoScrollResponse represents the response of invitation list
+//type InvitationInfoScrollResponse struct {
+//	Invitations []InvitationInfo `json:"invitations"`
+//}
+//
+//// InvitationStatusUpdateRequest represents the request to update invitation status
+//type InvitationStatusUpdateRequest struct {
+//	Status string `json:"status" binding:"required,oneof=ACCEPTED REJECTED"`
+//}

--- a/internal/invitation/dto.go
+++ b/internal/invitation/dto.go
@@ -11,7 +11,12 @@ type InvitationInfoScrollResponse struct {
 	Invitations []InvitationInfo `json:"invitations"`
 }
 
-//// InvitationStatusUpdateRequest represents the request to update invitation status
-//type InvitationStatusUpdateRequest struct {
-//	Status string `json:"status" binding:"required,oneof=ACCEPTED REJECTED"`
-//}
+// // InvitationStatusUpdateRequest represents the request to update invitation status
+type InvitationStatusUpdateRequest struct {
+	Status string `json:"status" binding:"required,oneof=ACCEPTED REJECTED"`
+}
+
+// InvitationIDParam is used to bind invitationId path parameter
+type InvitationIDParam struct {
+	InvitationID int64 `uri:"invitationId" binding:"gt=0"`
+}

--- a/internal/invitation/errors.go
+++ b/internal/invitation/errors.go
@@ -1,0 +1,35 @@
+package invitation
+
+import (
+	"net/http"
+
+	sharedError "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/error"
+)
+
+var (
+	// ErrInvitationNotFound is returned when an invitation is not found
+	ErrInvitationNotFound = sharedError.NewDomainError("INVITATION_NOT_FOUND")
+
+	// ErrAlreadyRespondedInvitation is returned when trying to respond to an already responded invitation
+	ErrAlreadyRespondedInvitation = sharedError.NewDomainError("ALREADY_RESPONDED_INVITATION")
+)
+
+const (
+	invitationNotFound         = "INVITATION_NOT_FOUND"
+	alreadyRespondedInvitation = "ALREADY_RESPONDED_INVITATION"
+)
+
+func init() {
+	// Register domain error responses
+	sharedError.RegisterDomainErrorResponse(invitationNotFound, sharedError.ErrorResponse{
+		Status:  http.StatusNotFound,
+		Code:    "INVITATION-001",
+		Message: "방 초대장을 찾을 수 없습니다.",
+	})
+
+	sharedError.RegisterDomainErrorResponse(alreadyRespondedInvitation, sharedError.ErrorResponse{
+		Status:  http.StatusConflict,
+		Code:    "INVITATION-002",
+		Message: "이미 응답한 초대장입니다.",
+	})
+}

--- a/internal/invitation/errors.go
+++ b/internal/invitation/errors.go
@@ -12,11 +12,15 @@ var (
 
 	// ErrAlreadyRespondedInvitation is returned when trying to respond to an already responded invitation
 	ErrAlreadyRespondedInvitation = sharedError.NewDomainError("ALREADY_RESPONDED_INVITATION")
+
+	// ErrInvalidInvitationResponse is returned when an invalid invitation response is provided
+	ErrInvalidInvitationResponse = sharedError.NewDomainError("INVALID_INVITATION_RESPONSE")
 )
 
 const (
 	invitationNotFound         = "INVITATION_NOT_FOUND"
 	alreadyRespondedInvitation = "ALREADY_RESPONDED_INVITATION"
+	invalidInvitationResponse  = "INVALID_INVITATION_RESPONSE"
 )
 
 func init() {
@@ -31,5 +35,11 @@ func init() {
 		Status:  http.StatusConflict,
 		Code:    "INVITATION-002",
 		Message: "이미 응답한 초대장입니다.",
+	})
+
+	sharedError.RegisterDomainErrorResponse(invalidInvitationResponse, sharedError.ErrorResponse{
+		Status:  http.StatusBadRequest,
+		Code:    "INVITATION-003",
+		Message: "유효하지 않은 초대장 응답입니다.",
 	})
 }

--- a/internal/invitation/get_invitations_api_test.go
+++ b/internal/invitation/get_invitations_api_test.go
@@ -1,0 +1,67 @@
+package invitation_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/invitation"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/model"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetInvitations_ReturnsPendingOnly(t *testing.T) {
+	invitationHandler, db, inviter := setupInvitationTestEnvironment(t)
+	invitee := testutil.CreateTestMemberWithIndex(t, db, 400)
+	room := testutil.CreateTestRoom(t, db, inviter.ID, "Room", "설명")
+
+	pending := &model.Invitation{
+		InviterName: "초대한 사람",
+		InviteeID:   invitee.ID,
+		RoomID:      room.ID,
+		Status:      model.InvitationPending,
+	}
+	require.NoError(t, db.Create(pending).Error)
+
+	accepted := &model.Invitation{
+		InviterName: "다른 사람",
+		InviteeID:   invitee.ID,
+		RoomID:      room.ID,
+		Status:      model.InvitationAccepted,
+	}
+	require.NoError(t, db.Create(accepted).Error)
+
+	router := testutil.SetupAuthenticatedRouter(invitee.ID)
+	router.GET("/api/v1/invitations", invitationHandler.GetInvitations)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodGet,
+		URL:    "/api/v1/invitations",
+	})
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+
+	var response invitation.InvitationInfoScrollResponse
+	testutil.ParseResponse(t, recorder, &response)
+	if assert.Len(t, response.Invitations, 1) {
+		info := response.Invitations[0]
+		assert.Equal(t, pending.ID, info.InvitationID)
+		assert.Equal(t, pending.InviterName, info.InviterName)
+		assert.Equal(t, room.Name, info.RoomName)
+		assert.Equal(t, room.Description, info.RoomDescription)
+	}
+}
+
+func TestGetInvitations_Unauthorized(t *testing.T) {
+	invitationHandler, _, _ := setupInvitationTestEnvironment(t)
+	router := testutil.SetupTestRouter()
+	router.GET("/api/v1/invitations", invitationHandler.GetInvitations)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodGet,
+		URL:    "/api/v1/invitations",
+	})
+
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+}

--- a/internal/invitation/handler.go
+++ b/internal/invitation/handler.go
@@ -45,25 +45,25 @@ func (h *InvitationHandler) InviteMembers(c *gin.Context) {
 }
 
 // GetInvitations handles GET /api/v1/invitations - 내가 받은 초대 목록 조회
-//func (h *InvitationHandler) GetInvitations(c *gin.Context) {
-//	memberID, ok := sharedHttp.RequireMemberID(c)
-//	if !ok {
-//		return
-//	}
-//
-//	response, err := h.invitationUseCase.GetInvitationInfoScroll(c.Request.Context(), memberID)
-//	if err != nil {
-//		if resp, ok := sharedError.ResolveDomainError(err); ok {
-//			sharedHttp.RespondError(c, err, resp)
-//			return
-//		}
-//
-//		sharedHttp.RespondError(c, err, sharedError.InternalServerError)
-//		return
-//	}
-//
-//	c.JSON(http.StatusOK, response)
-//}
+func (h *InvitationHandler) GetInvitations(c *gin.Context) {
+	memberID, ok := sharedHttp.RequireMemberID(c)
+	if !ok {
+		return
+	}
+
+	response, err := h.invitationUseCase.GetInvitationInfoScroll(c.Request.Context(), memberID)
+	if err != nil {
+		if resp, ok := sharedError.ResolveDomainError(err); ok {
+			sharedHttp.RespondError(c, err, resp)
+			return
+		}
+
+		sharedHttp.RespondError(c, err, sharedError.InternalServerError)
+		return
+	}
+
+	c.JSON(http.StatusOK, response)
+}
 
 // RespondToInvitation handles PATCH /api/v1/invitations/:invitationId - 초대 응답
 //func (h *InvitationHandler) RespondToInvitation(c *gin.Context) {

--- a/internal/invitation/handler.go
+++ b/internal/invitation/handler.go
@@ -1,0 +1,104 @@
+package invitation
+
+import (
+	"net/http"
+
+	sharedError "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/error"
+	sharedHttp "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/http"
+	"github.com/gin-gonic/gin"
+)
+
+type InvitationHandler struct {
+	invitationUseCase *InvitationUseCase
+}
+
+func NewInvitationHandler(invitationUseCase *InvitationUseCase) *InvitationHandler {
+	return &InvitationHandler{
+		invitationUseCase: invitationUseCase,
+	}
+}
+
+// InviteMembers handles POST /api/v2/invitations - 회원 초대 (V2)
+func (h *InvitationHandler) InviteMembers(c *gin.Context) {
+	memberID, ok := sharedHttp.RequireMemberID(c)
+	if !ok {
+		return
+	}
+
+	var request InviteMembersRequest
+	if !sharedHttp.BindJSON(c, &request) {
+		return
+	}
+
+	response, err := h.invitationUseCase.InviteMembersToRoom(c.Request.Context(), memberID, &request)
+	if err != nil {
+		if resp, ok := sharedError.ResolveDomainError(err); ok {
+			sharedHttp.RespondError(c, err, resp)
+			return
+		}
+
+		sharedHttp.RespondError(c, err, sharedError.InternalServerError)
+		return
+	}
+
+	c.JSON(http.StatusCreated, response)
+}
+
+// GetInvitations handles GET /api/v1/invitations - 내가 받은 초대 목록 조회
+//func (h *InvitationHandler) GetInvitations(c *gin.Context) {
+//	memberID, ok := sharedHttp.RequireMemberID(c)
+//	if !ok {
+//		return
+//	}
+//
+//	response, err := h.invitationUseCase.GetInvitationInfoScroll(c.Request.Context(), memberID)
+//	if err != nil {
+//		if resp, ok := sharedError.ResolveDomainError(err); ok {
+//			sharedHttp.RespondError(c, err, resp)
+//			return
+//		}
+//
+//		sharedHttp.RespondError(c, err, sharedError.InternalServerError)
+//		return
+//	}
+//
+//	c.JSON(http.StatusOK, response)
+//}
+
+// RespondToInvitation handles PATCH /api/v1/invitations/:invitationId - 초대 응답
+//func (h *InvitationHandler) RespondToInvitation(c *gin.Context) {
+//	memberID, ok := sharedHttp.RequireMemberID(c)
+//	if !ok {
+//		return
+//	}
+//
+//	// Parse invitation ID from URL
+//	invitationIDStr := c.Param("invitationId")
+//	invitationID, err := strconv.ParseInt(invitationIDStr, 10, 64)
+//	if err != nil || invitationID <= 0 {
+//		sharedHttp.RespondError(c, err, sharedError.ErrorResponse{
+//			Status:  http.StatusBadRequest,
+//			Code:    "INVITATION-003",
+//			Message: "잘 못된 초대장 입니다.",
+//		})
+//		return
+//	}
+//
+//	var request InvitationStatusUpdateRequest
+//	if !sharedHttp.BindJSON(c, &request) {
+//		return
+//	}
+//
+//	response, err := h.invitationUseCase.UpdateInvitationStatus(c.Request.Context(), memberID, invitationID, &request)
+//	if err != nil {
+//		if resp, ok := sharedError.ResolveDomainError(err); ok {
+//			sharedHttp.RespondError(c, err, resp)
+//			return
+//		}
+//
+//		sharedHttp.RespondError(c, err, sharedError.InternalServerError)
+//		return
+//	}
+//
+//	c.JSON(http.StatusOK, response)
+//}

--- a/internal/invitation/handler.go
+++ b/internal/invitation/handler.go
@@ -66,39 +66,32 @@ func (h *InvitationHandler) GetInvitations(c *gin.Context) {
 }
 
 // RespondToInvitation handles PATCH /api/v1/invitations/:invitationId - 초대 응답
-//func (h *InvitationHandler) RespondToInvitation(c *gin.Context) {
-//	memberID, ok := sharedHttp.RequireMemberID(c)
-//	if !ok {
-//		return
-//	}
-//
-//	// Parse invitation ID from URL
-//	invitationIDStr := c.Param("invitationId")
-//	invitationID, err := strconv.ParseInt(invitationIDStr, 10, 64)
-//	if err != nil || invitationID <= 0 {
-//		sharedHttp.RespondError(c, err, sharedError.ErrorResponse{
-//			Status:  http.StatusBadRequest,
-//			Code:    "INVITATION-003",
-//			Message: "잘 못된 초대장 입니다.",
-//		})
-//		return
-//	}
-//
-//	var request InvitationStatusUpdateRequest
-//	if !sharedHttp.BindJSON(c, &request) {
-//		return
-//	}
-//
-//	response, err := h.invitationUseCase.UpdateInvitationStatus(c.Request.Context(), memberID, invitationID, &request)
-//	if err != nil {
-//		if resp, ok := sharedError.ResolveDomainError(err); ok {
-//			sharedHttp.RespondError(c, err, resp)
-//			return
-//		}
-//
-//		sharedHttp.RespondError(c, err, sharedError.InternalServerError)
-//		return
-//	}
-//
-//	c.JSON(http.StatusOK, response)
-//}
+func (h *InvitationHandler) RespondToInvitation(c *gin.Context) {
+	memberID, ok := sharedHttp.RequireMemberID(c)
+	if !ok {
+		return
+	}
+
+	var path InvitationIDParam
+	if !sharedHttp.BindURI(c, &path) {
+		return
+	}
+
+	var request InvitationStatusUpdateRequest
+	if !sharedHttp.BindJSON(c, &request) {
+		return
+	}
+
+	response, err := h.invitationUseCase.UpdateInvitationStatus(c.Request.Context(), memberID, path.InvitationID, &request)
+	if err != nil {
+		if resp, ok := sharedError.ResolveDomainError(err); ok {
+			sharedHttp.RespondError(c, err, resp)
+			return
+		}
+
+		sharedHttp.RespondError(c, err, sharedError.InternalServerError)
+		return
+	}
+
+	c.JSON(http.StatusOK, response)
+}

--- a/internal/invitation/invite_members_api_test.go
+++ b/internal/invitation/invite_members_api_test.go
@@ -1,0 +1,133 @@
+package invitation_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/invitation"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/model"
+	sharedError "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/error"
+	sharedHttp "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/http"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInviteMembers_SuccessSkipsDuplicatesAndExistingPending(t *testing.T) {
+	handler, db, inviter := setupInvitationTestEnvironment(t)
+	room := testutil.CreateTestRoom(t, db, inviter.ID, "Test Room", "설명")
+	inviteeOne := testutil.CreateTestMemberWithIndex(t, db, 100)
+	inviteeTwo := testutil.CreateTestMemberWithIndex(t, db, 101)
+
+	// Existing pending invitation for inviteeOne should be ignored
+	existing := &model.Invitation{
+		InviteeID:   inviteeOne.ID,
+		RoomID:      room.ID,
+		InviterName: "Existing",
+		Status:      model.InvitationPending,
+	}
+	require.NoError(t, db.Create(existing).Error)
+
+	router := testutil.SetupAuthenticatedRouter(inviter.ID)
+	router.POST("/api/v2/invitations", handler.InviteMembers)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodPost,
+		URL:    "/api/v2/invitations",
+		Body: invitation.InviteMembersRequest{
+			RoomID:    room.ID,
+			MemberIDs: []int64{inviteeOne.ID, inviteeTwo.ID, inviteeTwo.ID},
+		},
+	})
+
+	assert.Equal(t, http.StatusCreated, recorder.Code)
+
+	var response sharedHttp.MessageResponse
+	testutil.ParseResponse(t, recorder, &response)
+	assert.Equal(t, "초대를 완료했습니다.", response.Message)
+
+	var invitations []model.Invitation
+	require.NoError(t, db.Where("room_id = ?", room.ID).Find(&invitations).Error)
+	assert.Len(t, invitations, 2)
+
+	var countOne int64
+	require.NoError(t, db.Model(&model.Invitation{}).
+		Where("room_id = ? AND invitee_id = ?", room.ID, inviteeOne.ID).
+		Count(&countOne).Error)
+	assert.Equal(t, int64(1), countOne)
+
+	var countTwo int64
+	require.NoError(t, db.Model(&model.Invitation{}).
+		Where("room_id = ? AND invitee_id = ?", room.ID, inviteeTwo.ID).
+		Count(&countTwo).Error)
+	assert.Equal(t, int64(1), countTwo)
+}
+
+func TestInviteMembers_MemberNotFound(t *testing.T) {
+	handler, db, inviter := setupInvitationTestEnvironment(t)
+	room := testutil.CreateTestRoom(t, db, inviter.ID, "Test Room", "설명")
+	invitee := testutil.CreateTestMemberWithIndex(t, db, 200)
+
+	router := testutil.SetupAuthenticatedRouter(inviter.ID)
+	router.POST("/api/v2/invitations", handler.InviteMembers)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodPost,
+		URL:    "/api/v2/invitations",
+		Body: invitation.InviteMembersRequest{
+			RoomID:    room.ID,
+			MemberIDs: []int64{invitee.ID, 999999},
+		},
+	})
+
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
+
+	var errorResponse sharedError.ErrorResponse
+	testutil.ParseResponse(t, recorder, &errorResponse)
+	assert.Equal(t, "MEMBER-001", errorResponse.Code)
+}
+
+func TestInviteMembers_AlreadyMember(t *testing.T) {
+	handler, db, inviter := setupInvitationTestEnvironment(t)
+	room := testutil.CreateTestRoom(t, db, inviter.ID, "Test Room", "설명")
+	members := testutil.AddMembersToRoom(t, db, room.ID, 1)
+	existing := members[0]
+
+	router := testutil.SetupAuthenticatedRouter(inviter.ID)
+	router.POST("/api/v2/invitations", handler.InviteMembers)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodPost,
+		URL:    "/api/v2/invitations",
+		Body: invitation.InviteMembersRequest{
+			RoomID:    room.ID,
+			MemberIDs: []int64{existing.ID},
+		},
+	})
+
+	assert.Equal(t, http.StatusConflict, recorder.Code)
+
+	var errorResponse sharedError.ErrorResponse
+	testutil.ParseResponse(t, recorder, &errorResponse)
+	assert.Equal(t, "ROOM-006", errorResponse.Code)
+}
+
+func TestInviteMembers_Unauthorized(t *testing.T) {
+	handler, db, inviter := setupInvitationTestEnvironment(t)
+	room := testutil.CreateTestRoom(t, db, inviter.ID, "Test Room", "설명")
+	invitee := testutil.CreateTestMemberWithIndex(t, db, 300)
+
+	router := testutil.SetupTestRouter()
+	router.POST("/api/v2/invitations", handler.InviteMembers)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodPost,
+		URL:    "/api/v2/invitations",
+		Body: invitation.InviteMembersRequest{
+			RoomID:    room.ID,
+			MemberIDs: []int64{invitee.ID},
+		},
+	})
+
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+}

--- a/internal/invitation/repository.go
+++ b/internal/invitation/repository.go
@@ -32,17 +32,17 @@ func (r *InvitationRepository) CreateAll(ctx context.Context, db *gorm.DB, invit
 }
 
 // FindByInviteeIDAndID retrieves an invitation by invitee ID and invitation ID
-//func (r *InvitationRepository) FindByInviteeIDAndID(ctx context.Context, db *gorm.DB, inviteeID, invitationID int64) (*model.Invitation, error) {
-//	var invitation model.Invitation
-//	err := db.WithContext(ctx).
-//		Where("invitee_id = ? AND id = ?", inviteeID, invitationID).
-//		First(&invitation).Error
-//
-//	if err != nil {
-//		return nil, err
-//	}
-//	return &invitation, nil
-//}
+func (r *InvitationRepository) FindByInviteeIDAndID(ctx context.Context, db *gorm.DB, inviteeID, invitationID int64) (*model.Invitation, error) {
+	var invitation model.Invitation
+	err := db.WithContext(ctx).
+		Where("invitee_id = ? AND id = ?", inviteeID, invitationID).
+		First(&invitation).Error
+
+	if err != nil {
+		return nil, err
+	}
+	return &invitation, nil
+}
 
 // FindInfosByInviteeIDAndStatus retrieves invitation infos by invitee ID and status
 func (r *InvitationRepository) FindInfosByInviteeIDAndStatus(ctx context.Context, db *gorm.DB, inviteeID int64, status model.InvitationStatus) ([]InvitationInfo, error) {
@@ -88,6 +88,6 @@ func (r *InvitationRepository) FindByRoomIDAndStatusAndInviteeIDs(ctx context.Co
 }
 
 // Update saves the invitation
-//func (r *InvitationRepository) Update(ctx context.Context, db *gorm.DB, invitation *model.Invitation) error {
-//	return db.WithContext(ctx).Save(invitation).Error
-//}
+func (r *InvitationRepository) Update(ctx context.Context, db *gorm.DB, invitation *model.Invitation) error {
+	return db.WithContext(ctx).Save(invitation).Error
+}

--- a/internal/invitation/repository.go
+++ b/internal/invitation/repository.go
@@ -1,0 +1,93 @@
+package invitation
+
+import (
+	"context"
+	"time"
+
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/model"
+	"gorm.io/gorm"
+)
+
+// InvitationInfo represents invitation information with inviter and room details
+type InvitationInfo struct {
+	InvitationID    int64     `json:"invitationId"`
+	InviterName     string    `json:"inviterName"`
+	RoomName        string    `json:"roomName"`
+	RoomDescription string    `json:"roomDescription"`
+	CreatedTime     time.Time `json:"createdTime"`
+}
+
+type InvitationRepository struct{}
+
+func NewInvitationRepository() *InvitationRepository {
+	return &InvitationRepository{}
+}
+
+// CreateAll saves multiple invitations
+func (r *InvitationRepository) CreateAll(ctx context.Context, db *gorm.DB, invitations []*model.Invitation) error {
+	if len(invitations) == 0 {
+		return nil
+	}
+	return db.WithContext(ctx).Create(&invitations).Error
+}
+
+// FindByInviteeIDAndID retrieves an invitation by invitee ID and invitation ID
+//func (r *InvitationRepository) FindByInviteeIDAndID(ctx context.Context, db *gorm.DB, inviteeID, invitationID int64) (*model.Invitation, error) {
+//	var invitation model.Invitation
+//	err := db.WithContext(ctx).
+//		Where("invitee_id = ? AND id = ?", inviteeID, invitationID).
+//		First(&invitation).Error
+//
+//	if err != nil {
+//		return nil, err
+//	}
+//	return &invitation, nil
+//}
+
+// FindInfosByInviteeIDAndStatus retrieves invitation infos by invitee ID and status
+//func (r *InvitationRepository) FindInfosByInviteeIDAndStatus(ctx context.Context, db *gorm.DB, inviteeID int64, status model.InvitationStatus) ([]InvitationInfo, error) {
+//	var results []InvitationInfo
+//
+//	err := db.WithContext(ctx).
+//		Table("invitation i").
+//		Select(`
+//			i.id as invitation_id,
+//			i.inviter_name,
+//			r.name as room_name,
+//			r.description as room_description,
+//			i.created_time
+//		`).
+//		Joins("JOIN room r ON i.room_id = r.id").
+//		Where("i.invitee_id = ? AND i.status = ?", inviteeID, status).
+//		Order("i.created_time DESC").
+//		Scan(&results).Error
+//
+//	if err != nil {
+//		return nil, err
+//	}
+//
+//	return results, nil
+//}
+
+// FindByRoomIDAndStatusAndInviteeIDs retrieves invitations by room ID, status, and invitee IDs
+func (r *InvitationRepository) FindByRoomIDAndStatusAndInviteeIDs(ctx context.Context, db *gorm.DB, roomID int64, status model.InvitationStatus, inviteeIDs []int64) ([]*model.Invitation, error) {
+	if len(inviteeIDs) == 0 {
+		return []*model.Invitation{}, nil
+	}
+
+	var invitations []*model.Invitation
+	err := db.WithContext(ctx).
+		Where("room_id = ? AND status = ? AND invitee_id IN ?", roomID, status, inviteeIDs).
+		Find(&invitations).Error
+
+	if err != nil {
+		return nil, err
+	}
+
+	return invitations, nil
+}
+
+// Update saves the invitation
+//func (r *InvitationRepository) Update(ctx context.Context, db *gorm.DB, invitation *model.Invitation) error {
+//	return db.WithContext(ctx).Save(invitation).Error
+//}

--- a/internal/invitation/repository.go
+++ b/internal/invitation/repository.go
@@ -45,29 +45,29 @@ func (r *InvitationRepository) CreateAll(ctx context.Context, db *gorm.DB, invit
 //}
 
 // FindInfosByInviteeIDAndStatus retrieves invitation infos by invitee ID and status
-//func (r *InvitationRepository) FindInfosByInviteeIDAndStatus(ctx context.Context, db *gorm.DB, inviteeID int64, status model.InvitationStatus) ([]InvitationInfo, error) {
-//	var results []InvitationInfo
-//
-//	err := db.WithContext(ctx).
-//		Table("invitation i").
-//		Select(`
-//			i.id as invitation_id,
-//			i.inviter_name,
-//			r.name as room_name,
-//			r.description as room_description,
-//			i.created_time
-//		`).
-//		Joins("JOIN room r ON i.room_id = r.id").
-//		Where("i.invitee_id = ? AND i.status = ?", inviteeID, status).
-//		Order("i.created_time DESC").
-//		Scan(&results).Error
-//
-//	if err != nil {
-//		return nil, err
-//	}
-//
-//	return results, nil
-//}
+func (r *InvitationRepository) FindInfosByInviteeIDAndStatus(ctx context.Context, db *gorm.DB, inviteeID int64, status model.InvitationStatus) ([]InvitationInfo, error) {
+	var results []InvitationInfo
+
+	err := db.WithContext(ctx).
+		Table("invitation i").
+		Select(`
+			i.id as invitation_id,
+			i.inviter_name,
+			r.name as room_name,
+			r.description as room_description,
+			i.created_time
+		`).
+		Joins("JOIN room r ON i.room_id = r.id").
+		Where("i.invitee_id = ? AND i.status = ?", inviteeID, status).
+		Order("i.created_time DESC").
+		Scan(&results).Error
+
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
 
 // FindByRoomIDAndStatusAndInviteeIDs retrieves invitations by room ID, status, and invitee IDs
 func (r *InvitationRepository) FindByRoomIDAndStatusAndInviteeIDs(ctx context.Context, db *gorm.DB, roomID int64, status model.InvitationStatus, inviteeIDs []int64) ([]*model.Invitation, error) {

--- a/internal/invitation/respond_to_invitation_api_test.go
+++ b/internal/invitation/respond_to_invitation_api_test.go
@@ -1,0 +1,179 @@
+package invitation_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/invitation"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/model"
+	sharedError "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/error"
+	sharedHttp "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/http"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestRespondToInvitation_AcceptSuccess(t *testing.T) {
+	handler, db, inviter := setupInvitationTestEnvironment(t)
+	room := testutil.CreateTestRoom(t, db, inviter.ID, "Room Accept", "방 설명")
+	invitee := testutil.CreateTestMemberWithIndex(t, db, 500)
+
+	pending := &model.Invitation{
+		InviterName: inviter.Name,
+		InviteeID:   invitee.ID,
+		RoomID:      room.ID,
+		Status:      model.InvitationPending,
+	}
+	require.NoError(t, db.Create(pending).Error)
+
+	router := testutil.SetupAuthenticatedRouter(invitee.ID)
+	router.PATCH("/api/v1/invitations/:invitationId", handler.RespondToInvitation)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodPatch,
+		URL:    fmt.Sprintf("/api/v1/invitations/%d", pending.ID),
+		Body: invitation.InvitationStatusUpdateRequest{
+			Status: string(model.InvitationAccepted),
+		},
+	})
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+
+	var response sharedHttp.MessageResponse
+	testutil.ParseResponse(t, recorder, &response)
+	assert.Equal(t, "기도방 초대를 수락했습니다.", response.Message)
+
+	var updated model.Invitation
+	require.NoError(t, db.First(&updated, pending.ID).Error)
+	assert.Equal(t, model.InvitationAccepted, updated.Status)
+	assert.NotNil(t, updated.ResponseTime)
+
+	var memberRoom model.MemberRoom
+	require.NoError(t, db.Where("member_id = ? AND room_id = ?", invitee.ID, room.ID).First(&memberRoom).Error)
+	assert.Equal(t, model.RoomRoleMember, memberRoom.Role)
+}
+
+func TestRespondToInvitation_RejectSuccess(t *testing.T) {
+	handler, db, inviter := setupInvitationTestEnvironment(t)
+	room := testutil.CreateTestRoom(t, db, inviter.ID, "Room Reject", "방 설명")
+	invitee := testutil.CreateTestMemberWithIndex(t, db, 510)
+
+	pending := &model.Invitation{
+		InviterName: inviter.Name,
+		InviteeID:   invitee.ID,
+		RoomID:      room.ID,
+		Status:      model.InvitationPending,
+	}
+	require.NoError(t, db.Create(pending).Error)
+
+	router := testutil.SetupAuthenticatedRouter(invitee.ID)
+	router.PATCH("/api/v1/invitations/:invitationId", handler.RespondToInvitation)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodPatch,
+		URL:    fmt.Sprintf("/api/v1/invitations/%d", pending.ID),
+		Body: invitation.InvitationStatusUpdateRequest{
+			Status: string(model.InvitationRejected),
+		},
+	})
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+
+	var response sharedHttp.MessageResponse
+	testutil.ParseResponse(t, recorder, &response)
+	assert.Equal(t, "기도방 초대를 거절했습니다.", response.Message)
+
+	var updated model.Invitation
+	require.NoError(t, db.First(&updated, pending.ID).Error)
+	assert.Equal(t, model.InvitationRejected, updated.Status)
+	assert.NotNil(t, updated.ResponseTime)
+
+	var memberRoom model.MemberRoom
+	err := db.Where("member_id = ? AND room_id = ?", invitee.ID, room.ID).First(&memberRoom).Error
+	assert.ErrorIs(t, err, gorm.ErrRecordNotFound)
+}
+
+func TestRespondToInvitation_NotFound(t *testing.T) {
+	handler, db, _ := setupInvitationTestEnvironment(t)
+	invitee := testutil.CreateTestMemberWithIndex(t, db, 520)
+
+	router := testutil.SetupAuthenticatedRouter(invitee.ID)
+	router.PATCH("/api/v1/invitations/:invitationId", handler.RespondToInvitation)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodPatch,
+		URL:    "/api/v1/invitations/999999",
+		Body: invitation.InvitationStatusUpdateRequest{
+			Status: string(model.InvitationAccepted),
+		},
+	})
+
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
+
+	var errorResponse sharedError.ErrorResponse
+	testutil.ParseResponse(t, recorder, &errorResponse)
+	assert.Equal(t, "INVITATION-001", errorResponse.Code)
+}
+
+func TestRespondToInvitation_Unauthorized(t *testing.T) {
+	handler, db, inviter := setupInvitationTestEnvironment(t)
+	room := testutil.CreateTestRoom(t, db, inviter.ID, "Room Unauthorized", "방 설명")
+	invitee := testutil.CreateTestMemberWithIndex(t, db, 530)
+
+	pending := &model.Invitation{
+		InviterName: inviter.Name,
+		InviteeID:   invitee.ID,
+		RoomID:      room.ID,
+		Status:      model.InvitationPending,
+	}
+	require.NoError(t, db.Create(pending).Error)
+
+	router := testutil.SetupTestRouter()
+	router.PATCH("/api/v1/invitations/:invitationId", handler.RespondToInvitation)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodPatch,
+		URL:    fmt.Sprintf("/api/v1/invitations/%d", pending.ID),
+		Body: invitation.InvitationStatusUpdateRequest{
+			Status: string(model.InvitationAccepted),
+		},
+	})
+
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+}
+
+func TestRespondToInvitation_AlreadyResponded(t *testing.T) {
+	handler, db, inviter := setupInvitationTestEnvironment(t)
+	room := testutil.CreateTestRoom(t, db, inviter.ID, "Room Already Responded", "방 설명")
+	invitee := testutil.CreateTestMemberWithIndex(t, db, 540)
+
+	now := time.Now()
+	accepted := &model.Invitation{
+		InviterName:  inviter.Name,
+		InviteeID:    invitee.ID,
+		RoomID:       room.ID,
+		Status:       model.InvitationAccepted,
+		ResponseTime: &now,
+	}
+	require.NoError(t, db.Create(accepted).Error)
+
+	router := testutil.SetupAuthenticatedRouter(invitee.ID)
+	router.PATCH("/api/v1/invitations/:invitationId", handler.RespondToInvitation)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodPatch,
+		URL:    fmt.Sprintf("/api/v1/invitations/%d", accepted.ID),
+		Body: invitation.InvitationStatusUpdateRequest{
+			Status: string(model.InvitationAccepted),
+		},
+	})
+
+	assert.Equal(t, http.StatusConflict, recorder.Code)
+
+	var errorResponse sharedError.ErrorResponse
+	testutil.ParseResponse(t, recorder, &errorResponse)
+	assert.Equal(t, "INVITATION-002", errorResponse.Code)
+}

--- a/internal/invitation/service.go
+++ b/internal/invitation/service.go
@@ -1,0 +1,117 @@
+package invitation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/model"
+	"gorm.io/gorm"
+)
+
+type InvitationService struct {
+	invitationRepository *InvitationRepository
+}
+
+func NewInvitationService(invitationRepository *InvitationRepository) *InvitationService {
+	return &InvitationService{
+		invitationRepository: invitationRepository,
+	}
+}
+
+// CreatePending creates invitations for multiple invitees
+// Filters out invitees who already have a PENDING invitation to the same room
+func (s *InvitationService) CreatePending(ctx context.Context, db *gorm.DB, inviterName string, invitees []*model.Member, roomID int64) error {
+	if len(invitees) == 0 {
+		return nil
+	}
+
+	inviteeIDs := make([]int64, 0, len(invitees))
+	for _, invitee := range invitees {
+		inviteeIDs = append(inviteeIDs, invitee.ID)
+	}
+
+	// Find existing PENDING invitations
+	existingInvitations, err := s.invitationRepository.FindByRoomIDAndStatusAndInviteeIDs(
+		ctx, db, roomID, model.InvitationPending, inviteeIDs,
+	)
+	if err != nil {
+		return fmt.Errorf("기도방 초대 응답 대기 조회 실패: %w", err)
+	}
+
+	// 초대를 받고 대기중인 회원 제외
+	existingInviteeIDs := make(map[int64]bool)
+	for _, invitation := range existingInvitations {
+		existingInviteeIDs[invitation.InviteeID] = true
+	}
+
+	// Filter out invitees who already have PENDING invitations
+	var newInvitations []*model.Invitation
+	for _, invitee := range invitees {
+		if existingInviteeIDs[invitee.ID] {
+			continue
+		}
+
+		newInvitations = append(newInvitations, &model.Invitation{
+			InviterName: inviterName,
+			InviteeID:   invitee.ID,
+			RoomID:      roomID,
+			Status:      model.InvitationPending,
+		})
+	}
+
+	// Create new invitations
+	if len(newInvitations) > 0 {
+		if err := s.invitationRepository.CreateAll(ctx, db, newInvitations); err != nil {
+			return fmt.Errorf("기도방 초대 실패: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// FetchInvitationInfosByInviteeID retrieves pending invitation infos for a member
+//func (s *InvitationService) FetchInvitationInfosByInviteeID(ctx context.Context, db *gorm.DB, inviteeID int64) ([]InvitationInfo, error) {
+//	infos, err := s.invitationRepository.FindInfosByInviteeIDAndStatus(ctx, db, inviteeID, model.InvitationPending)
+//	if err != nil {
+//		return nil, fmt.Errorf("failed to fetch invitation infos: %w", err)
+//	}
+//	return infos, nil
+//}
+//
+//// FetchByInviteeIDAndID retrieves an invitation by invitee ID and invitation ID
+//func (s *InvitationService) FetchByInviteeIDAndID(ctx context.Context, db *gorm.DB, inviteeID, invitationID int64) (*model.Invitation, error) {
+//	invitation, err := s.invitationRepository.FindByInviteeIDAndID(ctx, db, inviteeID, invitationID)
+//	if err != nil {
+//		if errors.Is(err, gorm.ErrRecordNotFound) {
+//			return nil, ErrInvitationNotFound
+//		}
+//		return nil, fmt.Errorf("failed to fetch invitation: %w", err)
+//	}
+//	return invitation, nil
+//}
+//
+//// Accept accepts an invitation
+//func (s *InvitationService) Accept(ctx context.Context, db *gorm.DB, invitation *model.Invitation) error {
+//	if err := invitation.Accept(); err != nil {
+//		return ErrAlreadyRespondedInvitation
+//	}
+//
+//	if err := s.invitationRepository.Update(ctx, db, invitation); err != nil {
+//		return fmt.Errorf("failed to update invitation: %w", err)
+//	}
+//
+//	return nil
+//}
+//
+//// Reject rejects an invitation
+//func (s *InvitationService) Reject(ctx context.Context, db *gorm.DB, invitation *model.Invitation) error {
+//	if err := invitation.Reject(); err != nil {
+//		return ErrAlreadyRespondedInvitation
+//	}
+//
+//	if err := s.invitationRepository.Update(ctx, db, invitation); err != nil {
+//		return fmt.Errorf("failed to update invitation: %w", err)
+//	}
+//
+//	return nil
+//}

--- a/internal/invitation/service.go
+++ b/internal/invitation/service.go
@@ -2,6 +2,7 @@ package invitation
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/model"
@@ -78,40 +79,40 @@ func (s *InvitationService) FetchInvitationInfosByInviteeID(ctx context.Context,
 	return infos, nil
 }
 
-//// FetchByInviteeIDAndID retrieves an invitation by invitee ID and invitation ID
-//func (s *InvitationService) FetchByInviteeIDAndID(ctx context.Context, db *gorm.DB, inviteeID, invitationID int64) (*model.Invitation, error) {
-//	invitation, err := s.invitationRepository.FindByInviteeIDAndID(ctx, db, inviteeID, invitationID)
-//	if err != nil {
-//		if errors.Is(err, gorm.ErrRecordNotFound) {
-//			return nil, ErrInvitationNotFound
-//		}
-//		return nil, fmt.Errorf("failed to fetch invitation: %w", err)
-//	}
-//	return invitation, nil
-//}
-//
-//// Accept accepts an invitation
-//func (s *InvitationService) Accept(ctx context.Context, db *gorm.DB, invitation *model.Invitation) error {
-//	if err := invitation.Accept(); err != nil {
-//		return ErrAlreadyRespondedInvitation
-//	}
-//
-//	if err := s.invitationRepository.Update(ctx, db, invitation); err != nil {
-//		return fmt.Errorf("failed to update invitation: %w", err)
-//	}
-//
-//	return nil
-//}
-//
-//// Reject rejects an invitation
-//func (s *InvitationService) Reject(ctx context.Context, db *gorm.DB, invitation *model.Invitation) error {
-//	if err := invitation.Reject(); err != nil {
-//		return ErrAlreadyRespondedInvitation
-//	}
-//
-//	if err := s.invitationRepository.Update(ctx, db, invitation); err != nil {
-//		return fmt.Errorf("failed to update invitation: %w", err)
-//	}
-//
-//	return nil
-//}
+// FetchByInviteeIDAndID retrieves an invitation by invitee ID and invitation ID
+func (s *InvitationService) FetchByInviteeIDAndID(ctx context.Context, db *gorm.DB, inviteeID, invitationID int64) (*model.Invitation, error) {
+	invitation, err := s.invitationRepository.FindByInviteeIDAndID(ctx, db, inviteeID, invitationID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("기도방 초대장을 찾을 수 없습니다: %w", ErrInvitationNotFound)
+		}
+		return nil, fmt.Errorf("기도방 초대장 조회 실패: %w", err)
+	}
+	return invitation, nil
+}
+
+// Accept accepts an invitation
+func (s *InvitationService) Accept(ctx context.Context, db *gorm.DB, invitation *model.Invitation) error {
+	if err := invitation.Accept(); err != nil {
+		return fmt.Errorf("이미 응답한 초대장입니다: %w", ErrAlreadyRespondedInvitation)
+	}
+
+	if err := s.invitationRepository.Update(ctx, db, invitation); err != nil {
+		return fmt.Errorf("기도방 초대장 상태 업데이트 실패: %w", err)
+	}
+
+	return nil
+}
+
+// Reject rejects an invitation
+func (s *InvitationService) Reject(ctx context.Context, db *gorm.DB, invitation *model.Invitation) error {
+	if err := invitation.Reject(); err != nil {
+		return fmt.Errorf("이미 응답한 초대장입니다: %w", ErrAlreadyRespondedInvitation)
+	}
+
+	if err := s.invitationRepository.Update(ctx, db, invitation); err != nil {
+		return fmt.Errorf("기도방 초대장 상태 업데이트 실패: %w", err)
+	}
+
+	return nil
+}

--- a/internal/invitation/service.go
+++ b/internal/invitation/service.go
@@ -70,14 +70,14 @@ func (s *InvitationService) CreatePending(ctx context.Context, db *gorm.DB, invi
 }
 
 // FetchInvitationInfosByInviteeID retrieves pending invitation infos for a member
-//func (s *InvitationService) FetchInvitationInfosByInviteeID(ctx context.Context, db *gorm.DB, inviteeID int64) ([]InvitationInfo, error) {
-//	infos, err := s.invitationRepository.FindInfosByInviteeIDAndStatus(ctx, db, inviteeID, model.InvitationPending)
-//	if err != nil {
-//		return nil, fmt.Errorf("failed to fetch invitation infos: %w", err)
-//	}
-//	return infos, nil
-//}
-//
+func (s *InvitationService) FetchInvitationInfosByInviteeID(ctx context.Context, db *gorm.DB, inviteeID int64) ([]InvitationInfo, error) {
+	infos, err := s.invitationRepository.FindInfosByInviteeIDAndStatus(ctx, db, inviteeID, model.InvitationPending)
+	if err != nil {
+		return nil, fmt.Errorf("기도방 초대 목록 조회 실패: %w", err)
+	}
+	return infos, nil
+}
+
 //// FetchByInviteeIDAndID retrieves an invitation by invitee ID and invitation ID
 //func (s *InvitationService) FetchByInviteeIDAndID(ctx context.Context, db *gorm.DB, inviteeID, invitationID int64) (*model.Invitation, error) {
 //	invitation, err := s.invitationRepository.FindByInviteeIDAndID(ctx, db, inviteeID, invitationID)

--- a/internal/invitation/test_helpers_test.go
+++ b/internal/invitation/test_helpers_test.go
@@ -1,0 +1,37 @@
+package invitation_test
+
+import (
+	testing "testing"
+
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/invitation"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/member"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/model"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/room"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/testutil"
+	"gorm.io/gorm"
+)
+
+// setupInvitationTestEnvironment wires dependencies needed for invitation handler tests.
+func setupInvitationTestEnvironment(t *testing.T) (*invitation.InvitationHandler, *gorm.DB, *model.Member) {
+	t.Helper()
+
+	db := testutil.SetupTestDB(t)
+	t.Cleanup(func() {
+		testutil.CleanupTestDB(t, db)
+	})
+
+	inviter := testutil.CreateTestMember(t, db)
+
+	memberRepo := member.NewMemberRepository()
+	memberService := member.NewMemberService(memberRepo)
+	roomRepo := room.NewRoomRepository()
+	memberRoomRepo := room.NewMemberRoomRepository()
+	roomService := room.NewRoomService(roomRepo, memberRoomRepo, memberService)
+
+	invitationRepo := invitation.NewInvitationRepository()
+	invitationService := invitation.NewInvitationService(invitationRepo)
+	invitationUseCase := invitation.NewInvitationUseCase(db, invitationService, roomService, memberService)
+	invitationHandler := invitation.NewInvitationHandler(invitationUseCase)
+
+	return invitationHandler, db, inviter
+}

--- a/internal/invitation/usecase.go
+++ b/internal/invitation/usecase.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/member"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/model"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/room"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/database"
 	sharedHttp "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/http"
@@ -98,67 +99,66 @@ func (uc *InvitationUseCase) GetInvitationInfoScroll(ctx context.Context, member
 }
 
 // UpdateInvitationStatus updates the status of an invitation (accept or reject)
-//
-//	func (uc *InvitationUseCase) UpdateInvitationStatus(ctx context.Context, memberID, invitationID int64, request *InvitationStatusUpdateRequest) (*sharedHttp.MessageResponse, error) {
-//		log := logger.FromContext(ctx)
-//		log.Info("초대 응답", "memberID", memberID, "invitationID", invitationID, "status", request.Status)
-//
-//		var result *sharedHttp.MessageResponse
-//		err := database.WithTransaction(ctx, uc.db, func(tx *gorm.DB) error {
-//			// 1. 초대장 조회 및 권한 검증
-//			invitation, err := uc.invitationService.FetchByInviteeIDAndID(ctx, tx, memberID, invitationID)
-//			if err != nil {
-//				return err
-//			}
-//
-//			// 2. 상태별 처리
-//			status := model.InvitationStatus(request.Status)
-//			switch status {
-//			case model.InvitationAccepted:
-//				// 수락
-//				if err := uc.invitationService.Accept(ctx, tx, invitation); err != nil {
-//					return err
-//				}
-//
-//				// 방에 자동 가입
-//				room, err := uc.roomService.GetRoomByID(ctx, tx, invitation.RoomID)
-//				if err != nil {
-//					return err
-//				}
-//
-//				invitee, err := uc.memberService.GetByID(ctx, tx, invitation.InviteeID)
-//				if err != nil {
-//					return err
-//				}
-//
-//				if err := uc.roomService.AddMemberToRoom(ctx, tx, invitee, room, model.RoomRoleMember); err != nil {
-//					return err
-//				}
-//
-//				result = &sharedHttp.MessageResponse{Message: "기도방 초대를 수락했습니다."}
-//
-//			case model.InvitationRejected:
-//				// 거절
-//				if err := uc.invitationService.Reject(ctx, tx, invitation); err != nil {
-//					return err
-//				}
-//
-//				result = &sharedHttp.MessageResponse{Message: "기도방 초대를 거절했습니다."}
-//
-//			default:
-//				return fmt.Errorf("invalid invitation status: %s", request.Status)
-//			}
-//
-//			return nil
-//		})
-//
-//		if err != nil {
-//			return nil, err
-//		}
-//
-//		log.Info("초대 응답 완료", "memberID", memberID, "invitationID", invitationID, "status", request.Status)
-//		return result, nil
-//	}
+func (uc *InvitationUseCase) UpdateInvitationStatus(ctx context.Context, memberID, invitationID int64, request *InvitationStatusUpdateRequest) (*sharedHttp.MessageResponse, error) {
+	log := logger.FromContext(ctx)
+	log.Info("초대 응답 시작", "memberID", memberID, "invitationID", invitationID, "status", request.Status)
+
+	var result *sharedHttp.MessageResponse
+	err := database.WithTransaction(ctx, uc.db, func(tx *gorm.DB) error {
+		// 1. 초대장 조회 및 권한 검증
+		invitation, err := uc.invitationService.FetchByInviteeIDAndID(ctx, tx, memberID, invitationID)
+		if err != nil {
+			return err
+		}
+
+		// 2. 상태별 처리
+		status := model.InvitationStatus(request.Status)
+		switch status {
+		case model.InvitationAccepted:
+			// 수락
+			if err := uc.invitationService.Accept(ctx, tx, invitation); err != nil {
+				return err
+			}
+
+			// 방에 자동 가입
+			room, err := uc.roomService.GetRoomByID(ctx, tx, invitation.RoomID)
+			if err != nil {
+				return err
+			}
+
+			invitee, err := uc.memberService.GetByID(ctx, tx, invitation.InviteeID)
+			if err != nil {
+				return err
+			}
+
+			if err := uc.roomService.AddMemberToRoom(ctx, tx, invitee, room, model.RoomRoleMember); err != nil {
+				return err
+			}
+
+			result = &sharedHttp.MessageResponse{Message: "기도방 초대를 수락했습니다."}
+
+		case model.InvitationRejected:
+			// 거절
+			if err := uc.invitationService.Reject(ctx, tx, invitation); err != nil {
+				return err
+			}
+
+			result = &sharedHttp.MessageResponse{Message: "기도방 초대를 거절했습니다."}
+
+		default:
+			return ErrInvalidInvitationResponse
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	log.Info("초대 응답 완료", "memberID", memberID, "invitationID", invitationID, "status", request.Status)
+	return result, nil
+}
 func uniqueInt64s(values []int64) []int64 {
 	if len(values) == 0 {
 		return []int64{}

--- a/internal/invitation/usecase.go
+++ b/internal/invitation/usecase.go
@@ -83,18 +83,19 @@ func (uc *InvitationUseCase) InviteMembersToRoom(ctx context.Context, inviterMem
 	return result, nil
 }
 
-//// GetInvitationInfoScroll retrieves pending invitation infos for a member
-//func (uc *InvitationUseCase) GetInvitationInfoScroll(ctx context.Context, memberID int64) (*InvitationInfoScrollResponse, error) {
-//	log := logger.FromContext(ctx)
-//	log.Info("초대 목록 조회", "memberID", memberID)
-//
-//	infos, err := uc.invitationService.FetchInvitationInfosByInviteeID(ctx, uc.db, memberID)
-//	if err != nil {
-//		return nil, err
-//	}
-//
-//	return &InvitationInfoScrollResponse{Invitations: infos}, nil
-//}
+// GetInvitationInfoScroll retrieves pending invitation infos for a member
+func (uc *InvitationUseCase) GetInvitationInfoScroll(ctx context.Context, memberID int64) (*InvitationInfoScrollResponse, error) {
+	log := logger.FromContext(ctx)
+	log.Info("초대 목록 조회 시작")
+
+	infos, err := uc.invitationService.FetchInvitationInfosByInviteeID(ctx, uc.db, memberID)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Info("초대 목록 조회 완료")
+	return &InvitationInfoScrollResponse{Invitations: infos}, nil
+}
 
 // UpdateInvitationStatus updates the status of an invitation (accept or reject)
 //

--- a/internal/invitation/usecase.go
+++ b/internal/invitation/usecase.go
@@ -1,0 +1,177 @@
+package invitation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/member"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/room"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/database"
+	sharedHttp "github.com/changhyeonkim/pray-together/go-api-server/internal/shared/http"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/shared/logger"
+	"gorm.io/gorm"
+)
+
+type InvitationUseCase struct {
+	db                *gorm.DB
+	invitationService *InvitationService
+	roomService       *room.RoomService
+	memberService     *member.MemberService
+}
+
+func NewInvitationUseCase(
+	db *gorm.DB,
+	invitationService *InvitationService,
+	roomService *room.RoomService,
+	memberService *member.MemberService,
+) *InvitationUseCase {
+	return &InvitationUseCase{
+		db:                db,
+		invitationService: invitationService,
+		roomService:       roomService,
+		memberService:     memberService,
+	}
+}
+
+// InviteMembersToRoom invites members to a room (V2)
+func (uc *InvitationUseCase) InviteMembersToRoom(ctx context.Context, inviterMemberID int64, request *InviteMembersRequest) (*sharedHttp.MessageResponse, error) {
+	log := logger.FromContext(ctx)
+	log.Info("회원 초대 시작", "inviterMemberID", inviterMemberID, "roomID", request.RoomID, "memberIDs", request.MemberIDs)
+	memberIDs := uniqueInt64s(request.MemberIDs)
+
+	var result *sharedHttp.MessageResponse
+	err := database.WithTransaction(ctx, uc.db, func(tx *gorm.DB) error {
+		// 1. 초대자 권한 검증
+		if err := uc.roomService.ValidateMemberExistInRoom(ctx, tx, inviterMemberID, request.RoomID); err != nil {
+			return err
+		}
+
+		// 2. 초대 대상 중 이미 방 멤버가 있는지 검증 (있으면 전체 요청 실패)
+		if err := uc.roomService.ValidateMembersNotExistInRoom(ctx, tx, memberIDs, request.RoomID); err != nil {
+			return err
+		}
+
+		// 3. 초대자 조회
+		inviter, err := uc.memberService.GetByID(ctx, tx, inviterMemberID)
+		if err != nil {
+			return err
+		}
+
+		// 4. 초대 대상자 조회 (존재 여부 검증)
+		invitees, err := uc.memberService.GetByIDs(ctx, tx, memberIDs)
+		if err != nil {
+			return err
+		}
+		if len(invitees) != len(memberIDs) {
+			return fmt.Errorf("존재하지 않는 회원이 포함되어 있습니다: %w", member.ErrMemberNotFound)
+		}
+
+		// 5. 초대장 일괄 생성 (중복 PENDING 초대 필터링 포함)
+		if err := uc.invitationService.CreatePending(ctx, tx, inviter.Name, invitees, request.RoomID); err != nil {
+			return err
+		}
+
+		result = &sharedHttp.MessageResponse{Message: "초대를 완료했습니다."}
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	log.Info("회원 초대 완료", "inviterMemberID", inviterMemberID, "roomID", request.RoomID)
+	return result, nil
+}
+
+//// GetInvitationInfoScroll retrieves pending invitation infos for a member
+//func (uc *InvitationUseCase) GetInvitationInfoScroll(ctx context.Context, memberID int64) (*InvitationInfoScrollResponse, error) {
+//	log := logger.FromContext(ctx)
+//	log.Info("초대 목록 조회", "memberID", memberID)
+//
+//	infos, err := uc.invitationService.FetchInvitationInfosByInviteeID(ctx, uc.db, memberID)
+//	if err != nil {
+//		return nil, err
+//	}
+//
+//	return &InvitationInfoScrollResponse{Invitations: infos}, nil
+//}
+
+// UpdateInvitationStatus updates the status of an invitation (accept or reject)
+//
+//	func (uc *InvitationUseCase) UpdateInvitationStatus(ctx context.Context, memberID, invitationID int64, request *InvitationStatusUpdateRequest) (*sharedHttp.MessageResponse, error) {
+//		log := logger.FromContext(ctx)
+//		log.Info("초대 응답", "memberID", memberID, "invitationID", invitationID, "status", request.Status)
+//
+//		var result *sharedHttp.MessageResponse
+//		err := database.WithTransaction(ctx, uc.db, func(tx *gorm.DB) error {
+//			// 1. 초대장 조회 및 권한 검증
+//			invitation, err := uc.invitationService.FetchByInviteeIDAndID(ctx, tx, memberID, invitationID)
+//			if err != nil {
+//				return err
+//			}
+//
+//			// 2. 상태별 처리
+//			status := model.InvitationStatus(request.Status)
+//			switch status {
+//			case model.InvitationAccepted:
+//				// 수락
+//				if err := uc.invitationService.Accept(ctx, tx, invitation); err != nil {
+//					return err
+//				}
+//
+//				// 방에 자동 가입
+//				room, err := uc.roomService.GetRoomByID(ctx, tx, invitation.RoomID)
+//				if err != nil {
+//					return err
+//				}
+//
+//				invitee, err := uc.memberService.GetByID(ctx, tx, invitation.InviteeID)
+//				if err != nil {
+//					return err
+//				}
+//
+//				if err := uc.roomService.AddMemberToRoom(ctx, tx, invitee, room, model.RoomRoleMember); err != nil {
+//					return err
+//				}
+//
+//				result = &sharedHttp.MessageResponse{Message: "기도방 초대를 수락했습니다."}
+//
+//			case model.InvitationRejected:
+//				// 거절
+//				if err := uc.invitationService.Reject(ctx, tx, invitation); err != nil {
+//					return err
+//				}
+//
+//				result = &sharedHttp.MessageResponse{Message: "기도방 초대를 거절했습니다."}
+//
+//			default:
+//				return fmt.Errorf("invalid invitation status: %s", request.Status)
+//			}
+//
+//			return nil
+//		})
+//
+//		if err != nil {
+//			return nil, err
+//		}
+//
+//		log.Info("초대 응답 완료", "memberID", memberID, "invitationID", invitationID, "status", request.Status)
+//		return result, nil
+//	}
+func uniqueInt64s(values []int64) []int64 {
+	if len(values) == 0 {
+		return []int64{}
+	}
+
+	seen := make(map[int64]struct{}, len(values))
+	unique := make([]int64, 0, len(values))
+	for _, v := range values {
+		if _, exists := seen[v]; exists {
+			continue
+		}
+		seen[v] = struct{}{}
+		unique = append(unique, v)
+	}
+
+	return unique
+}

--- a/internal/member/repository.go
+++ b/internal/member/repository.go
@@ -80,6 +80,20 @@ func (m *MemberRepository) FindByID(ctx context.Context, db *gorm.DB, ID int64) 
 	return &member, nil
 }
 
+// FindByIDs - ID 리스트로 회원 일괄 조회
+func (m *MemberRepository) FindByIDs(ctx context.Context, db *gorm.DB, memberIDs []int64) ([]*model.Member, error) {
+	if len(memberIDs) == 0 {
+		return []*model.Member{}, nil
+	}
+
+	var members []*model.Member
+	err := db.WithContext(ctx).Where("id IN ?", memberIDs).Find(&members).Error
+	if err != nil {
+		return nil, err
+	}
+	return members, nil
+}
+
 // Delete - 회원 삭제
 func (m *MemberRepository) Delete(ctx context.Context, db *gorm.DB, memberID int64) error {
 	result := db.WithContext(ctx).Delete(&model.Member{}, memberID)

--- a/internal/member/service.go
+++ b/internal/member/service.go
@@ -48,6 +48,15 @@ func (s *MemberService) GetByEmail(ctx context.Context, db *gorm.DB, email strin
 	return member, nil
 }
 
+// GetByIDs - ID 리스트로 회원 일괄 조회
+func (s *MemberService) GetByIDs(ctx context.Context, db *gorm.DB, memberIDs []int64) ([]*model.Member, error) {
+	members, err := s.memberRepository.FindByIDs(ctx, db, memberIDs)
+	if err != nil {
+		return nil, fmt.Errorf("회원 일괄 조회 실패: %w", err)
+	}
+	return members, nil
+}
+
 // ExistsByEmail - 이메일 중복 확인
 func (s *MemberService) ExistsByEmail(ctx context.Context, db *gorm.DB, email string) (bool, error) {
 	exists, err := s.memberRepository.IsExistByEmail(ctx, db, email)

--- a/internal/model/invitation.go
+++ b/internal/model/invitation.go
@@ -1,0 +1,46 @@
+package model
+
+import (
+	"time"
+)
+
+// InvitationStatus represents the status of an invitation
+// Java의 InvitationStatus enum과 동일
+type InvitationStatus string
+
+const (
+	InvitationPending  InvitationStatus = "PENDING"
+	InvitationAccepted InvitationStatus = "ACCEPTED"
+	InvitationRejected InvitationStatus = "REJECTED"
+)
+
+// Invitation represents an invitation to join a room
+type Invitation struct {
+	ID           int64            `gorm:"column:id;primaryKey;autoIncrement"`
+	InviteeID    int64            `gorm:"column:invitee_id;not null;index:idx_invitation_invitee_status"`
+	RoomID       int64            `gorm:"column:room_id;not null;index:idx_invitation_room_invitee_status"`
+	InviterName  string           `gorm:"column:inviter_name;type:VARCHAR2(10);not null"`
+	Status       InvitationStatus `gorm:"column:status;type:VARCHAR2(20);not null;default:'PENDING';index:idx_invitation_invitee_status,idx_invitation_room_invitee_status"`
+	ResponseTime *time.Time       `gorm:"column:response_time"`
+
+	// Relations
+	Invitee *Member `gorm:"foreignKey:InviteeID;references:ID;constraint:OnDelete:CASCADE"`
+	Room    *Room   `gorm:"foreignKey:RoomID;references:ID;constraint:OnDelete:CASCADE"`
+
+	BaseEntity
+}
+
+// TableName specifies the table name for Invitation
+func (*Invitation) TableName() string {
+	return "invitation"
+}
+
+// validatePendingStatus checks if the invitation is in PENDING status
+// Java: private void validatePendingStatus() throws AlreadyRespondedInvitationException
+//func (i *Invitation) validatePendingStatus() error {
+//	if i.Status != InvitationPending {
+//		// Java에서는 AlreadyRespondedInvitationException(this.id, this.status)를 던짐
+//		return fmt.Errorf("already responded invitation: id=%d, status=%s", i.ID, i.Status)
+//	}
+//	return nil
+//}

--- a/internal/model/invitation.go
+++ b/internal/model/invitation.go
@@ -1,11 +1,11 @@
 package model
 
 import (
+	"fmt"
 	"time"
 )
 
 // InvitationStatus represents the status of an invitation
-// Java의 InvitationStatus enum과 동일
 type InvitationStatus string
 
 const (
@@ -35,12 +35,31 @@ func (*Invitation) TableName() string {
 	return "invitation"
 }
 
-// validatePendingStatus checks if the invitation is in PENDING status
-// Java: private void validatePendingStatus() throws AlreadyRespondedInvitationException
-//func (i *Invitation) validatePendingStatus() error {
-//	if i.Status != InvitationPending {
-//		// Java에서는 AlreadyRespondedInvitationException(this.id, this.status)를 던짐
-//		return fmt.Errorf("already responded invitation: id=%d, status=%s", i.ID, i.Status)
-//	}
-//	return nil
-//}
+func (i *Invitation) Accept() error {
+	if err := i.validatePendingStatus(); err != nil {
+		return err
+	}
+
+	now := time.Now()
+	i.Status = InvitationAccepted
+	i.ResponseTime = &now
+	return nil
+}
+
+func (i *Invitation) Reject() error {
+	if err := i.validatePendingStatus(); err != nil {
+		return err
+	}
+
+	now := time.Now()
+	i.Status = InvitationRejected
+	i.ResponseTime = &now
+	return nil
+}
+
+func (i *Invitation) validatePendingStatus() error {
+	if i.Status != InvitationPending {
+		return fmt.Errorf("이미 응답한 초대장 입니다: inviationId=%d, status=%s", i.ID, i.Status)
+	}
+	return nil
+}

--- a/internal/room/errors.go
+++ b/internal/room/errors.go
@@ -12,6 +12,7 @@ const (
 	memberRoomAlreadyExists = "MEMBER_ROOM_ALREADY_EXIST" // errInfo
 	someoneAlreadyExists    = "SOMEONE_ALREADY_EXIST"     // errInfo
 	invalidRoomID           = "INVALID_ROOM_ID"           // errInfo
+	memberAlreadyInRoom     = "MEMBER_ALREADY_IN_ROOM"    // errInfo
 )
 
 var (
@@ -20,6 +21,7 @@ var (
 	ErrMemberRoomAlreadyExists = sharedError.NewDomainError(memberRoomAlreadyExists)
 	ErrSomeoneAlreadyExists    = sharedError.NewDomainError(someoneAlreadyExists)
 	ErrInvalidRoomID           = sharedError.NewDomainError(invalidRoomID)
+	ErrMemberAlreadyInRoom     = sharedError.NewDomainError(memberAlreadyInRoom)
 )
 
 func init() {
@@ -52,5 +54,11 @@ func init() {
 		Status:  http.StatusBadRequest,
 		Code:    "ROOM-005",
 		Message: "잘 못된 방을 선택하셨습니다.",
+	})
+
+	sharedError.RegisterDomainErrorResponse(memberAlreadyInRoom, sharedError.ErrorResponse{
+		Status:  http.StatusConflict,
+		Code:    "ROOM-006",
+		Message: "이미 방에 가입된 회원이 있습니다.",
 	})
 }

--- a/internal/room/repository.go
+++ b/internal/room/repository.go
@@ -171,6 +171,21 @@ func (r *MemberRoomRepository) IsExistMemberInRoom(ctx context.Context, db *gorm
 	return count > 0, nil
 }
 
+// FindMemberIDsByRoomID fetches all member IDs in a room
+func (r *MemberRoomRepository) FindMemberIDsByRoomID(ctx context.Context, db *gorm.DB, roomID int64) ([]int64, error) {
+	var memberIDs []int64
+	err := db.WithContext(ctx).
+		Model(&model.MemberRoom{}).
+		Where("room_id = ?", roomID).
+		Pluck("member_id", &memberIDs).Error
+
+	if err != nil {
+		return nil, err
+	}
+
+	return memberIDs, nil
+}
+
 func (r *MemberRoomRepository) FindMemberRooms(ctx context.Context, db *gorm.DB, roomID int64) ([]RoomMember, error) {
 	var results []RoomMember
 	err := db.WithContext(ctx).

--- a/internal/room/service.go
+++ b/internal/room/service.go
@@ -178,6 +178,31 @@ func (s *RoomService) ValidateMemberExistInRoom(ctx context.Context, tx *gorm.DB
 	return nil
 }
 
+// ValidateMembersNotExistInRoom ensures none of the given member IDs already belong to the room.
+func (s *RoomService) ValidateMembersNotExistInRoom(ctx context.Context, tx *gorm.DB, memberIDs []int64, roomID int64) error {
+	if len(memberIDs) == 0 {
+		return nil
+	}
+
+	existingMemberIDs, err := s.memberRoomRepository.FindMemberIDsByRoomID(ctx, tx, roomID)
+	if err != nil {
+		return fmt.Errorf("방 멤버 조회 실패: %w", err)
+	}
+
+	existing := make(map[int64]struct{}, len(existingMemberIDs))
+	for _, id := range existingMemberIDs {
+		existing[id] = struct{}{}
+	}
+
+	for _, memberID := range memberIDs {
+		if _, ok := existing[memberID]; ok {
+			return fmt.Errorf("이미 방에 가입된 회원이 있습니다: %w", ErrMemberAlreadyInRoom)
+		}
+	}
+
+	return nil
+}
+
 func (s *RoomService) GetRoomByID(ctx context.Context, tx *gorm.DB, roomID int64) (*model.Room, error) {
 	room, err := s.roomRepository.FindByID(ctx, tx, roomID)
 	if err != nil {

--- a/internal/room/service.go
+++ b/internal/room/service.go
@@ -213,3 +213,12 @@ func (s *RoomService) GetRoomByID(ctx context.Context, tx *gorm.DB, roomID int64
 	}
 	return room, nil
 }
+
+// AddMemberToRoom adds a member to a room with the specified role
+func (s *RoomService) AddMemberToRoom(ctx context.Context, tx *gorm.DB, member *model.Member, room *model.Room, role string) error {
+	memberRoom := model.NewRoomMember(member.ID, room.ID, role, true)
+	if err := s.memberRoomRepository.Create(ctx, tx, memberRoom); err != nil {
+		return fmt.Errorf("방 멤버 추가 실패: %w", err)
+	}
+	return nil
+}

--- a/internal/router/routes.go
+++ b/internal/router/routes.go
@@ -28,6 +28,7 @@ func Setup(router *gin.Engine, cfg *config.Config, db *database.DB) {
 	memberRoomRepository := room.NewMemberRoomRepository()
 	prayerRepository := prayer.NewPrayerRepository()
 	refreshTokenRepository := auth.NewRefreshTokenRepository()
+	invitationRepository := invitation.NewInvitationRepository()
 
 	// OTP dependencies
 	otpCache := otp.NewInMemoryCache()
@@ -44,18 +45,21 @@ func Setup(router *gin.Engine, cfg *config.Config, db *database.DB) {
 	refreshTokenService := auth.NewRefreshTokenService(refreshTokenRepository)
 	roomService := room.NewRoomService(roomRepository, memberRoomRepository, memberService)
 	prayerService := prayer.NewPrayerService(prayerRepository)
+	invitationService := invitation.NewInvitationService(invitationRepository)
 
 	// usecase
 	memberUseCase := member.NewMemberUseCase(db.DB, memberService)
 	authUseCase := auth.NewAuthUseCase(db.DB, memberService, tokenManager, authService, otpService, refreshTokenService)
 	roomUseCase := room.NewRoomUseCase(db.DB, roomService)
 	prayerUseCase := prayer.NewPrayerUseCase(db.DB, prayerService, roomService, memberService)
+	invitationUseCase := invitation.NewInvitationUseCase(db.DB, invitationService, roomService, memberService)
 
 	// handler
 	authHandler := auth.NewAuthHandler(authUseCase)
 	memberHandler := member.NewMemberHandler(memberUseCase)
 	roomHandler := room.NewRoomHandler(roomUseCase)
 	prayerHandler := prayer.NewPrayerHandler(prayerUseCase)
+	invitationHandler := invitation.NewInvitationHandler(invitationUseCase)
 
 	// API v1 routes
 	authV1 := router.Group("/api/v1/auth")
@@ -98,5 +102,11 @@ func Setup(router *gin.Engine, cfg *config.Config, db *database.DB) {
 		prayerV1.GET("/:titleId/contents", prayerHandler.FetchPrayerContents)
 		prayerV1.PUT("/:titleId/contents/:contentId", prayerHandler.UpdatePrayerContent)
 		prayerV1.DELETE("/:titleId/contents/:contentId", prayerHandler.DeletePrayerContent)
+	}
+	// Invitation API v2 routes
+	invitationV2 := router.Group("/api/v2/invitations")
+	invitationV2.Use(middleware.JWT(cfg))
+	{
+		invitationV2.POST("", invitationHandler.InviteMembers)
 	}
 }

--- a/internal/router/routes.go
+++ b/internal/router/routes.go
@@ -110,7 +110,7 @@ func Setup(router *gin.Engine, cfg *config.Config, db *database.DB) {
 	invitationV1.Use(middleware.JWT(cfg))
 	{
 		invitationV1.GET("", invitationHandler.GetInvitations)
-		//invitationV1.PATCH("/:invitationId", invitationHandler.RespondToInvitation)
+		invitationV1.PATCH("/:invitationId", invitationHandler.RespondToInvitation)
 	}
 
 	// Invitation API v2 routes

--- a/internal/router/routes.go
+++ b/internal/router/routes.go
@@ -6,6 +6,7 @@ import (
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/auth"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/auth/otp"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/config"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/invitation"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/member"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/meta"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/prayer"
@@ -103,6 +104,15 @@ func Setup(router *gin.Engine, cfg *config.Config, db *database.DB) {
 		prayerV1.PUT("/:titleId/contents/:contentId", prayerHandler.UpdatePrayerContent)
 		prayerV1.DELETE("/:titleId/contents/:contentId", prayerHandler.DeletePrayerContent)
 	}
+
+	// Invitation API v1 routes
+	invitationV1 := router.Group("/api/v1/invitations")
+	invitationV1.Use(middleware.JWT(cfg))
+	{
+		invitationV1.GET("", invitationHandler.GetInvitations)
+		//invitationV1.PATCH("/:invitationId", invitationHandler.RespondToInvitation)
+	}
+
 	// Invitation API v2 routes
 	invitationV2 := router.Group("/api/v2/invitations")
 	invitationV2.Use(middleware.JWT(cfg))

--- a/internal/shared/database/migration.go
+++ b/internal/shared/database/migration.go
@@ -32,8 +32,8 @@ func Migrate(db *gorm.DB, cfg *config.Config) error {
 	slog.Info("🗑️  기존 테이블 삭제 중...")
 
 	// Order matters: drop in reverse dependency order (FK constraints)
-	// member_room → room, member (FK 참조하는 테이블 먼저)
-	tableNames := []string{"member_room", "room", "refresh_token", "member"}
+	// member_room, invitation → room, member (FK 참조하는 테이블 먼저)
+	tableNames := []string{"invitation", "member_room", "room", "refresh_token", "member"}
 
 	for _, tableName := range tableNames {
 		// Check if table exists (Oracle)
@@ -74,6 +74,7 @@ func runAutoMigrate(db *gorm.DB) error {
 		// Dependent tables (with foreign keys)
 		&model.RefreshToken{}, // FK: member_id
 		&model.MemberRoom{},   // FK: room_id, member_id
+		&model.Invitation{},   // FK: invitee_id (member), room_id
 		&model.PrayerTitle{},
 		&model.PrayerContent{},
 	}

--- a/internal/shared/testutil/database.go
+++ b/internal/shared/testutil/database.go
@@ -27,6 +27,7 @@ func SetupTestDB(t *testing.T) *gorm.DB {
 		&model.MemberRoom{},
 		&model.Room{},
 		&model.Member{},
+		&model.Invitation{},
 		&model.RefreshToken{},
 		&model.PrayerTitle{},
 		&model.PrayerContent{},

--- a/internal/shared/validator/errors.go
+++ b/internal/shared/validator/errors.go
@@ -55,6 +55,8 @@ func getErrorMessage(fe validator.FieldError) string {
 				return "잘못된 회원을 선택하셨습니다."
 			case "TitleID":
 				return "잘못된 기도제목을 선택하셨습니다."
+			case "InvitationID":
+				return "잘못된 초대장을 선택하셨습니다."
 			default:
 				return "잘못된 값을 선택하셨습니다."
 			}


### PR DESCRIPTION
 📝 어떤 변경인가요?

  새로운 기능

  기도방 초대 API (V2)

  - POST /api/v2/invitations - 한 번에 여러 회원을 기도방에 초대

  초대 목록 조회 API (V1)

  - GET /api/v1/invitations - 내가 받은 PENDING 상태의 초대 목록 조회

  초대 응답 API (V1)

  - PATCH /api/v1/invitations/:invitationId - 초대 수락/거절

  주요 추가/수정 항목

  새로운 파일

  - internal/invitation/ 패키지 전체 (Handler, UseCase, Service, Repository)
  - internal/model/invitation.go - Invitation 엔티티
  - 통합 테스트 3개 (초대 생성, 목록 조회, 응답)

  수정된 파일

  | 파일                                    | 변경 사항                                                 |
  |---------------------------------------|-------------------------------------------------------|
  | internal/router/routes.go             | invitation V1, V2 엔드포인트 라우팅 추가                        |
  | internal/member/service.go            | GetByIDs 메서드 추가 (일괄 조회)                               |
  | internal/room/service.go              | ValidateMembersNotExistInRoom, AddMemberToRoom 메서드 추가 |
  | internal/shared/database/migration.go | Invitation 테이블 마이그레이션 추가                              |

  ---
  🎯 변경의 목적은 무엇인가요?

  배경

  사용자들이 다른 사용자를 기도방에 초대하고, 초대를 수락/거절할 수 있는 기능이 필요함

  목적

  - 기도방 멤버 확장을 위한 초대 시스템 구현
  - 중복 초대 방지를 통한 사용자 경험 개선
  - 초대 수락 시 자동으로 기도방 멤버로 등록

  ---
  🔧 어떻게 변경되었나요?

  4계층 아키텍처 구현

  1. Model Layer (internal/model/invitation.go)

  type Invitation struct {
      ID           int64            // Auto increment primary key
      InviteeID    int64            // 초대받은 사람
      RoomID       int64            // 초대할 기도방
      InviterName  string           // 초대한 사람 이름
      Status       InvitationStatus // PENDING, ACCEPTED, REJECTED
      ResponseTime *time.Time       // 응답 시간
      BaseEntity                    // created_at, updated_at
  }

  도메인 메서드:
  - Accept() - 초대 수락, ResponseTime 기록
  - Reject() - 초대 거절, ResponseTime 기록
  - validatePendingStatus() - PENDING 상태 검증

  2. Repository Layer (internal/invitation/repository.go)

  - FindByRoomIDAndStatusAndInviteeIDs - 중복 PENDING 초대 필터링용
  - FindInfosByInviteeIDAndStatus - 초대 목록 조회 (JOIN으로 room 정보 포함)
  - FindByInviteeIDAndID - 권한 검증용 조회
  - CreateAll - 일괄 생성

  3. Service Layer (internal/invitation/service.go)

  핵심 로직:
  - CreateInvitations - 중복 PENDING 초대 필터링
  // 1. 기존 PENDING 초대 조회
  // 2. 중복 제거 (inviteeID 기준)
  // 3. 새로운 초대만 생성

  4. UseCase Layer (internal/invitation/usecase.go)

  트랜잭션 처리:
  - InviteMembersToRoom - 초대자 권한 검증 → 중복 가입 검증 → 초대 생성
  - UpdateInvitationStatus - 초대 응답 → 수락 시 자동 멤버 등록

  5. Handler Layer (internal/invitation/handler.go)

  - JWT 인증 필수
  - URI 파라미터 바인딩 (invitationId)
  - 도메인 에러 매핑

  엔드포인트 상세

  POST /api/v2/invitations

  // Request
  {
    "roomId": 1,
    "memberIds": [100, 101, 102]
  }

  // Response (201 Created)
  {
    "message": "초대를 완료했습니다."
  }

  비즈니스 로직:
  1. 초대자가 해당 방의 멤버인지 검증
  2. 피초대자들이 이미 방 멤버가 아닌지 검증
  3. 기존 PENDING 초대가 있는 회원은 제외
  4. 새로운 초대만 생성

  GET /api/v1/invitations

  // Response (200 OK)
  {
    "invitations": [
      {
        "invitationId": 1,
        "inviterName": "홍길동",
        "roomName": "새벽 기도",
        "roomDescription": "매일 아침 6시"
      }
    ]
  }

  PATCH /api/v1/invitations/:invitationId

  // Request
  {
    "status": "ACCEPTED" // or "REJECTED"
  }

  // Response (200 OK)
  {
    "message": "기도방 초대를 수락했습니다."
  }

  비즈니스 로직:
  1. 초대장이 본인 것인지 검증 (inviteeId 확인)
  2. PENDING 상태인지 검증
  3. 수락 시 자동으로 방 멤버 등록 (role: MEMBER)
  4. ResponseTime 기록

  지원 메서드 추가

  Member Service

  // 여러 회원 ID로 일괄 조회
  func (s *MemberService) GetByIDs(ctx, db, []int64) ([]*Member, error)

  Room Service

  // 여러 회원이 방에 없는지 일괄 검증
  func (s *RoomService) ValidateMembersNotExistInRoom(ctx, db, []int64, roomID)

  // 방에 회원 추가
  func (s *RoomService) AddMemberToRoom(ctx, db, *Member, *Room, role)

  에러 처리

  | 에러 코드          | HTTP Status | 설명           |
  |----------------|-------------|--------------|
  | INVITATION-001 | 404         | 초대장을 찾을 수 없음 |
  | INVITATION-002 | 409         | 이미 응답한 초대장   |
  | INVITATION-003 | 400         | 잘못된 초대장 응답   |


  ---
    ⚠️ 특이 사항

  🔄 중복 초대 방지 로직

  - 같은 방에 대해 이미 PENDING 상태인 초대가 있으면 새로 생성하지 않음
  - 요청한 memberIds 중 일부만 필터링되어도 에러 없이 처리

  🗑️ 캐스케이드 삭제

  - Member 삭제 시 → 해당 member가 invitee인 초대 자동 삭제
  - Room 삭제 시 → 해당 room의 모든 초대 자동 삭제


  ---
  🔗 관련 이슈

  close #12