### PR TITLE
Feature/14 fcm token api

### DIFF
--- a/internal/app/router/routes.go
+++ b/internal/app/router/routes.go
@@ -129,5 +129,6 @@ func Setup(router *gin.Engine, cfg *config.Config, db *database.DB) {
 	fcmTokenV1.Use(middleware.JWT(cfg))
 	{
 		fcmTokenV1.POST("", fcmTokenHandler.RegisterToken)
+		fcmTokenV1.DELETE("", fcmTokenHandler.DeleteToken)
 	}
 }

--- a/internal/app/router/routes.go
+++ b/internal/app/router/routes.go
@@ -9,6 +9,7 @@ import (
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/app/shared/token"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/auth"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/auth/otp"
+	fcmtoken "github.com/changhyeonkim/pray-together/go-api-server/internal/fcm_token"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/invitation"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/member"
 	"github.com/changhyeonkim/pray-together/go-api-server/internal/meta"
@@ -30,6 +31,7 @@ func Setup(router *gin.Engine, cfg *config.Config, db *database.DB) {
 	prayerRepository := prayer.NewPrayerRepository()
 	refreshTokenRepository := auth.NewRefreshTokenRepository()
 	invitationRepository := invitation.NewInvitationRepository()
+	fcmTokenRepository := fcmtoken.NewFcmTokenRepository()
 
 	// OTP dependencies
 	otpCache := otp.NewInMemoryCache()
@@ -47,6 +49,7 @@ func Setup(router *gin.Engine, cfg *config.Config, db *database.DB) {
 	roomService := room.NewRoomService(roomRepository, memberRoomRepository, memberService)
 	prayerService := prayer.NewPrayerService(prayerRepository)
 	invitationService := invitation.NewInvitationService(invitationRepository)
+	fcmTokenService := fcmtoken.NewFcmTokenService(fcmTokenRepository)
 
 	// usecase
 	memberUseCase := member.NewMemberUseCase(db.DB, memberService)
@@ -54,6 +57,7 @@ func Setup(router *gin.Engine, cfg *config.Config, db *database.DB) {
 	roomUseCase := room.NewRoomUseCase(db.DB, roomService)
 	prayerUseCase := prayer.NewPrayerUseCase(db.DB, prayerService, roomService, memberService)
 	invitationUseCase := invitation.NewInvitationUseCase(db.DB, invitationService, roomService, memberService)
+	fcmTokenUseCase := fcmtoken.NewFcmTokenUseCase(db.DB, memberService, fcmTokenService)
 
 	// handler
 	authHandler := auth.NewAuthHandler(authUseCase)
@@ -61,6 +65,7 @@ func Setup(router *gin.Engine, cfg *config.Config, db *database.DB) {
 	roomHandler := room.NewRoomHandler(roomUseCase)
 	prayerHandler := prayer.NewPrayerHandler(prayerUseCase)
 	invitationHandler := invitation.NewInvitationHandler(invitationUseCase)
+	fcmTokenHandler := fcmtoken.NewHandler(fcmTokenUseCase)
 
 	// API v1 routes
 	authV1 := router.Group("/api/v1/auth")
@@ -118,5 +123,11 @@ func Setup(router *gin.Engine, cfg *config.Config, db *database.DB) {
 	invitationV2.Use(middleware.JWT(cfg))
 	{
 		invitationV2.POST("", invitationHandler.InviteMembers)
+	}
+
+	fcmTokenV1 := router.Group("/api/v1/fcm-token")
+	fcmTokenV1.Use(middleware.JWT(cfg))
+	{
+		fcmTokenV1.POST("", fcmTokenHandler.RegisterToken)
 	}
 }

--- a/internal/app/shared/testutil/database.go
+++ b/internal/app/shared/testutil/database.go
@@ -31,6 +31,7 @@ func SetupTestDB(t *testing.T) *gorm.DB {
 		&model.RefreshToken{},
 		&model.PrayerTitle{},
 		&model.PrayerContent{},
+		&model.FcmToken{},
 		// Add other models here as needed
 	)
 	if err != nil {

--- a/internal/app/shared/validator/errors.go
+++ b/internal/app/shared/validator/errors.go
@@ -34,6 +34,11 @@ func getErrorMessage(fe validator.FieldError) string {
 	switch fe.Tag() {
 	case "required":
 		return "필수 항목을 입력해 주세요."
+	case "notblank":
+		if fe.Field() == "FcmToken" {
+			return "값이 비어 있습니다."
+		}
+		return "공백만 입력할 수 없습니다."
 	case "email":
 		return "이메일 형식이 올바르지 않습니다."
 	case "min":

--- a/internal/app/shared/validator/notblank.go
+++ b/internal/app/shared/validator/notblank.go
@@ -7,12 +7,11 @@ import (
 	"github.com/go-playground/validator/v10"
 )
 
-// ValidateNotBlank checks that a string contains a non-whitespace character.
+// ValidateNotBlank ensures a string contains non-whitespace characters.
 func ValidateNotBlank(fl validator.FieldLevel) bool {
 	field := fl.Field()
 	if field.Kind() != reflect.String {
 		return false
 	}
-
 	return strings.TrimSpace(field.String()) != ""
 }

--- a/internal/app/shared/validator/notblank.go
+++ b/internal/app/shared/validator/notblank.go
@@ -1,0 +1,18 @@
+package validator
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// ValidateNotBlank checks that a string contains a non-whitespace character.
+func ValidateNotBlank(fl validator.FieldLevel) bool {
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+
+	return strings.TrimSpace(field.String()) != ""
+}

--- a/internal/app/shared/validator/register.go
+++ b/internal/app/shared/validator/register.go
@@ -25,7 +25,6 @@ func RegisterAll() error {
 		return fmt.Errorf("validator 엔진 가져오기 실패: %w", err)
 	}
 
-	// Register common validators
 	if err := v.RegisterValidation("phone", ValidatePhone); err != nil {
 		return fmt.Errorf("phone validator 등록 실패: %w", err)
 	}

--- a/internal/app/shared/validator/register.go
+++ b/internal/app/shared/validator/register.go
@@ -3,6 +3,7 @@ package validator
 import (
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/gin-gonic/gin/binding"
 	"github.com/go-playground/validator/v10"
@@ -28,7 +29,10 @@ func RegisterAll() error {
 	if err := v.RegisterValidation("phone", ValidatePhone); err != nil {
 		return fmt.Errorf("phone validator 등록 실패: %w", err)
 	}
+	if err := v.RegisterValidation("notblank", ValidateNotBlank); err != nil {
+		return fmt.Errorf("notblank validator 등록 실패: %w", err)
+	}
 
-	slog.Info("공통 Validator 등록 완료", "validators", "phone")
+	slog.Info("공통 Validator 등록 완료", "validators", strings.Join([]string{"phone", "notblank"}, ","))
 	return nil
 }

--- a/internal/fcm_token/delete_fcm_token_api_test.go
+++ b/internal/fcm_token/delete_fcm_token_api_test.go
@@ -1,0 +1,83 @@
+package fcm_token_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/app/shared/testutil"
+	fcmToken "github.com/changhyeonkim/pray-together/go-api-server/internal/fcm_token"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteFcmToken_Success(t *testing.T) {
+	handler, db, member := setupFcmTokenTestEnvironment(t)
+	require.NoError(t, db.Create(&model.FcmToken{MemberID: member.ID, Token: "token-to-delete", IsActive: true}).Error)
+
+	router := testutil.SetupAuthenticatedRouter(member.ID)
+	router.DELETE("/api/v1/fcm-token", handler.DeleteToken)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodDelete,
+		URL:    "/api/v1/fcm-token",
+		Body: fcmToken.DeleteFcmTokenRequest{
+			FcmToken: "token-to-delete",
+		},
+	})
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	var count int64
+	require.NoError(t, db.Model(&model.FcmToken{}).Count(&count).Error)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestDeleteFcmToken_IgnoredForOtherMember(t *testing.T) {
+	handler, db, member := setupFcmTokenTestEnvironment(t)
+	otherMember := testutil.CreateTestMemberWithIndex(t, db, 999)
+	require.NoError(t, db.Create(&model.FcmToken{MemberID: member.ID, Token: "my-token", IsActive: true}).Error)
+	require.NoError(t, db.Create(&model.FcmToken{MemberID: otherMember.ID, Token: "my-token", IsActive: true}).Error)
+
+	router := testutil.SetupAuthenticatedRouter(member.ID)
+	router.DELETE("/api/v1/fcm-token", handler.DeleteToken)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodDelete,
+		URL:    "/api/v1/fcm-token",
+		Body:   fcmToken.DeleteFcmTokenRequest{FcmToken: "my-token"},
+	})
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	var tokens []model.FcmToken
+	require.NoError(t, db.Order("member_id").Find(&tokens).Error)
+	assert.Len(t, tokens, 1)
+	assert.Equal(t, otherMember.ID, tokens[0].MemberID)
+}
+
+func TestDeleteFcmToken_ValidationError(t *testing.T) {
+	handler, _, member := setupFcmTokenTestEnvironment(t)
+	router := testutil.SetupAuthenticatedRouter(member.ID)
+	router.DELETE("/api/v1/fcm-token", handler.DeleteToken)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodDelete,
+		URL:    "/api/v1/fcm-token",
+		Body:   fcmToken.DeleteFcmTokenRequest{FcmToken: "   "},
+	})
+
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+}
+
+func TestDeleteFcmToken_Unauthorized(t *testing.T) {
+	handler, _, _ := setupFcmTokenTestEnvironment(t)
+	router := testutil.SetupTestRouter()
+	router.DELETE("/api/v1/fcm-token", handler.DeleteToken)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodDelete,
+		URL:    "/api/v1/fcm-token",
+		Body:   fcmToken.DeleteFcmTokenRequest{FcmToken: "token"},
+	})
+
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+}

--- a/internal/fcm_token/dto.go
+++ b/internal/fcm_token/dto.go
@@ -1,6 +1,13 @@
 package fcm_token
 
+import "strings"
+
 // RegisterFcmTokenRequest represents the request payload for registering an FCM token.
 type RegisterFcmTokenRequest struct {
 	FcmToken string `json:"fcmToken" binding:"required,notblank,max=512"`
+}
+
+// TrimmedToken removes leading/trailing spaces for safe persistence.
+func (r *RegisterFcmTokenRequest) TrimmedToken() string {
+	return strings.TrimSpace(r.FcmToken)
 }

--- a/internal/fcm_token/dto.go
+++ b/internal/fcm_token/dto.go
@@ -11,3 +11,13 @@ type RegisterFcmTokenRequest struct {
 func (r *RegisterFcmTokenRequest) TrimmedToken() string {
 	return strings.TrimSpace(r.FcmToken)
 }
+
+// DeleteFcmTokenRequest represents the request payload for deleting an FCM token.
+type DeleteFcmTokenRequest struct {
+	FcmToken string `json:"fcmToken" binding:"required,notblank,max=512"`
+}
+
+// TrimmedToken removes leading/trailing spaces for safe persistence.
+func (r *DeleteFcmTokenRequest) TrimmedToken() string {
+	return strings.TrimSpace(r.FcmToken)
+}

--- a/internal/fcm_token/dto.go
+++ b/internal/fcm_token/dto.go
@@ -1,0 +1,6 @@
+package fcm_token
+
+// RegisterFcmTokenRequest represents the request payload for registering an FCM token.
+type RegisterFcmTokenRequest struct {
+	FcmToken string `json:"fcmToken" binding:"required,notblank,max=512"`
+}

--- a/internal/fcm_token/handler.go
+++ b/internal/fcm_token/handler.go
@@ -1,0 +1,44 @@
+package fcm_token
+
+import (
+	"net/http"
+
+	sharedError "github.com/changhyeonkim/pray-together/go-api-server/internal/app/shared/error"
+	sharedHttp "github.com/changhyeonkim/pray-together/go-api-server/internal/app/shared/http"
+	"github.com/gin-gonic/gin"
+)
+
+// Handler exposes HTTP endpoints for managing FCM tokens.
+type Handler struct {
+	useCase *FcmTokenUseCase
+}
+
+// NewHandler constructs a new handler.
+func NewHandler(useCase *FcmTokenUseCase) *Handler {
+	return &Handler{useCase: useCase}
+}
+
+// RegisterToken handles POST /api/v1/fcm-token requests.
+func (h *Handler) RegisterToken(c *gin.Context) {
+	memberID, ok := sharedHttp.RequireMemberID(c)
+	if !ok {
+		return
+	}
+
+	var request RegisterFcmTokenRequest
+	if !sharedHttp.BindJSON(c, &request) {
+		return
+	}
+
+	if err := h.useCase.RegisterFcmToken(c.Request.Context(), memberID, request.FcmToken); err != nil {
+		if resp, ok := sharedError.ResolveDomainError(err); ok {
+			sharedHttp.RespondError(c, err, resp)
+			return
+		}
+
+		sharedHttp.RespondError(c, err, sharedError.InternalServerError)
+		return
+	}
+
+	c.Status(http.StatusOK)
+}

--- a/internal/fcm_token/handler.go
+++ b/internal/fcm_token/handler.go
@@ -44,3 +44,30 @@ func (h *Handler) RegisterToken(c *gin.Context) {
 
 	c.Status(http.StatusOK)
 }
+
+// DeleteToken handles DELETE /api/v1/fcm-token requests.
+func (h *Handler) DeleteToken(c *gin.Context) {
+	memberID, ok := sharedHttp.RequireMemberID(c)
+	if !ok {
+		return
+	}
+
+	var request DeleteFcmTokenRequest
+	if !sharedHttp.BindJSON(c, &request) {
+		return
+	}
+
+	token := request.TrimmedToken()
+
+	if err := h.useCase.DeleteFcmToken(c.Request.Context(), memberID, token); err != nil {
+		if resp, ok := sharedError.ResolveDomainError(err); ok {
+			sharedHttp.RespondError(c, err, resp)
+			return
+		}
+
+		sharedHttp.RespondError(c, err, sharedError.InternalServerError)
+		return
+	}
+
+	c.Status(http.StatusOK)
+}

--- a/internal/fcm_token/handler.go
+++ b/internal/fcm_token/handler.go
@@ -30,7 +30,9 @@ func (h *Handler) RegisterToken(c *gin.Context) {
 		return
 	}
 
-	if err := h.useCase.RegisterFcmToken(c.Request.Context(), memberID, request.FcmToken); err != nil {
+	token := request.TrimmedToken()
+
+	if err := h.useCase.RegisterFcmToken(c.Request.Context(), memberID, token); err != nil {
 		if resp, ok := sharedError.ResolveDomainError(err); ok {
 			sharedHttp.RespondError(c, err, resp)
 			return

--- a/internal/fcm_token/register_fcm_token_api_test.go
+++ b/internal/fcm_token/register_fcm_token_api_test.go
@@ -1,0 +1,114 @@
+package fcm_token_test
+
+import (
+	"net/http"
+	"testing"
+
+	sharedError "github.com/changhyeonkim/pray-together/go-api-server/internal/app/shared/error"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/app/shared/testutil"
+	fcmtoken "github.com/changhyeonkim/pray-together/go-api-server/internal/fcm_token"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterFcmToken_ReplacesExistingToken(t *testing.T) {
+	handler, db, member := setupFcmTokenTestEnvironment(t)
+
+	router := testutil.SetupAuthenticatedRouter(member.ID)
+	router.POST("/api/v1/fcm-token", handler.RegisterToken)
+
+	// First registration
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodPost,
+		URL:    "/api/v1/fcm-token",
+		Body: fcmtoken.RegisterFcmTokenRequest{
+			FcmToken: "first-token",
+		},
+	})
+	assert.Equal(t, http.StatusOK, recorder.Code)
+
+	var tokens []model.FcmToken
+	require.NoError(t, db.Find(&tokens).Error)
+	require.Len(t, tokens, 1)
+	assert.Equal(t, member.ID, tokens[0].MemberID)
+	assert.Equal(t, "first-token", tokens[0].Token)
+	assert.True(t, tokens[0].IsActive)
+
+	// Second registration should replace existing token and trim whitespace
+	recorder = testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodPost,
+		URL:    "/api/v1/fcm-token",
+		Body: fcmtoken.RegisterFcmTokenRequest{
+			FcmToken: "   second-token   ",
+		},
+	})
+	assert.Equal(t, http.StatusOK, recorder.Code)
+
+	tokens = nil
+	require.NoError(t, db.Find(&tokens).Error)
+	require.Len(t, tokens, 1)
+	assert.Equal(t, "second-token", tokens[0].Token)
+}
+
+func TestRegisterFcmToken_ValidationError(t *testing.T) {
+	handler, db, member := setupFcmTokenTestEnvironment(t)
+
+	router := testutil.SetupAuthenticatedRouter(member.ID)
+	router.POST("/api/v1/fcm-token", handler.RegisterToken)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodPost,
+		URL:    "/api/v1/fcm-token",
+		Body: fcmtoken.RegisterFcmTokenRequest{
+			FcmToken: "   ",
+		},
+	})
+
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	var errResp sharedError.ErrorResponse
+	testutil.ParseResponse(t, recorder, &errResp)
+	assert.Equal(t, "값이 비어 있습니다.", errResp.Message)
+
+	var count int64
+	require.NoError(t, db.Model(&model.FcmToken{}).Count(&count).Error)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestRegisterFcmToken_MemberNotFound(t *testing.T) {
+	handler, _, member := setupFcmTokenTestEnvironment(t)
+
+	missingMemberID := member.ID + 99999
+	router := testutil.SetupAuthenticatedRouter(missingMemberID)
+	router.POST("/api/v1/fcm-token", handler.RegisterToken)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodPost,
+		URL:    "/api/v1/fcm-token",
+		Body: fcmtoken.RegisterFcmTokenRequest{
+			FcmToken: "token-value",
+		},
+	})
+
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
+	var errResp sharedError.ErrorResponse
+	testutil.ParseResponse(t, recorder, &errResp)
+	assert.Equal(t, "MEMBER-001", errResp.Code)
+}
+
+func TestRegisterFcmToken_Unauthorized(t *testing.T) {
+	handler, _, _ := setupFcmTokenTestEnvironment(t)
+
+	router := testutil.SetupTestRouter()
+	router.POST("/api/v1/fcm-token", handler.RegisterToken)
+
+	recorder := testutil.ExecuteRequest(t, router, testutil.TestRequest{
+		Method: http.MethodPost,
+		URL:    "/api/v1/fcm-token",
+		Body: fcmtoken.RegisterFcmTokenRequest{
+			FcmToken: "token-value",
+		},
+	})
+
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+}

--- a/internal/fcm_token/repository.go
+++ b/internal/fcm_token/repository.go
@@ -26,3 +26,10 @@ func (r *FcmTokenRepository) DeleteByMemberID(ctx context.Context, db *gorm.DB, 
 		Where("member_id = ?", memberID).
 		Delete(&model.FcmToken{}).Error
 }
+
+// DeleteByTokenAndMemberID removes a token only if both token value and owner match.
+func (r *FcmTokenRepository) DeleteByTokenAndMemberID(ctx context.Context, db *gorm.DB, token string, memberID int64) error {
+	return db.WithContext(ctx).
+		Where("member_id = ? AND token = ?", memberID, token).
+		Delete(&model.FcmToken{}).Error
+}

--- a/internal/fcm_token/repository.go
+++ b/internal/fcm_token/repository.go
@@ -1,0 +1,28 @@
+package fcm_token
+
+import (
+	"context"
+
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/model"
+	"gorm.io/gorm"
+)
+
+// FcmTokenRepository encapsulates all persistence logic for FCM tokens.
+type FcmTokenRepository struct{}
+
+// NewFcmTokenRepository returns a new repository instance.
+func NewFcmTokenRepository() *FcmTokenRepository {
+	return &FcmTokenRepository{}
+}
+
+// Create inserts a new FCM token row.
+func (r *FcmTokenRepository) Create(ctx context.Context, db *gorm.DB, token *model.FcmToken) error {
+	return db.WithContext(ctx).Create(token).Error
+}
+
+// DeleteByMemberID removes all tokens that belong to the given member.
+func (r *FcmTokenRepository) DeleteByMemberID(ctx context.Context, db *gorm.DB, memberID int64) error {
+	return db.WithContext(ctx).
+		Where("member_id = ?", memberID).
+		Delete(&model.FcmToken{}).Error
+}

--- a/internal/fcm_token/service.go
+++ b/internal/fcm_token/service.go
@@ -1,0 +1,43 @@
+package fcm_token
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/model"
+	"gorm.io/gorm"
+)
+
+// FcmTokenService contains business logic for registering and deleting FCM tokens.
+type FcmTokenService struct {
+	repo *FcmTokenRepository
+}
+
+// NewFcmTokenService returns a new service instance.
+func NewFcmTokenService(repo *FcmTokenRepository) *FcmTokenService {
+	return &FcmTokenService{repo: repo}
+}
+
+// RegisterToken enforces the single-token-per-member policy by deleting previous tokens
+// and saving the new token within the provided transaction.
+func (s *FcmTokenService) RegisterToken(ctx context.Context, db *gorm.DB, memberID int64, token string) error {
+	normalized := strings.TrimSpace(token)
+	if normalized == "" {
+		return fmt.Errorf("공백 토큰은 등록할 수 없습니다")
+	}
+
+	if err := s.repo.DeleteByMemberID(ctx, db, memberID); err != nil {
+		return fmt.Errorf("기존 FCM 토큰 삭제 실패: %w", err)
+	}
+
+	entity := &model.FcmToken{
+		MemberID: memberID,
+		Token:    normalized,
+		IsActive: true,
+	}
+	if err := s.repo.Create(ctx, db, entity); err != nil {
+		return fmt.Errorf("FCM 토큰 저장 실패: %w", err)
+	}
+	return nil
+}

--- a/internal/fcm_token/service.go
+++ b/internal/fcm_token/service.go
@@ -41,3 +41,11 @@ func (s *FcmTokenService) RegisterToken(ctx context.Context, db *gorm.DB, member
 	}
 	return nil
 }
+
+// DeleteByMemberID removes a token by value scoped to the given member.
+func (s *FcmTokenService) DeleteByMemberID(ctx context.Context, db *gorm.DB, token string, memberID int64) error {
+	if err := s.repo.DeleteByTokenAndMemberID(ctx, db, strings.TrimSpace(token), memberID); err != nil {
+		return fmt.Errorf("FCM 토큰 삭제 실패: %w", err)
+	}
+	return nil
+}

--- a/internal/fcm_token/test_helpers_test.go
+++ b/internal/fcm_token/test_helpers_test.go
@@ -1,0 +1,34 @@
+package fcm_token_test
+
+import (
+	"testing"
+
+	testutil "github.com/changhyeonkim/pray-together/go-api-server/internal/app/shared/testutil"
+	fcmtoken "github.com/changhyeonkim/pray-together/go-api-server/internal/fcm_token"
+	memberpkg "github.com/changhyeonkim/pray-together/go-api-server/internal/member"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/model"
+	"gorm.io/gorm"
+)
+
+// setupFcmTokenTestEnvironment wires dependencies for FCM token handler tests.
+func setupFcmTokenTestEnvironment(t *testing.T) (*fcmtoken.Handler, *gorm.DB, *model.Member) {
+	t.Helper()
+
+	db := testutil.SetupTestDB(t)
+	t.Cleanup(func() {
+		testutil.CleanupTestDB(t, db)
+	})
+
+	member := testutil.CreateTestMember(t, db)
+
+	memberRepo := memberpkg.NewMemberRepository()
+	memberService := memberpkg.NewMemberService(memberRepo)
+
+	fcmRepo := fcmtoken.NewFcmTokenRepository()
+	fcmService := fcmtoken.NewFcmTokenService(fcmRepo)
+	useCase := fcmtoken.NewFcmTokenUseCase(db, memberService, fcmService)
+
+	handler := fcmtoken.NewHandler(useCase)
+
+	return handler, db, member
+}

--- a/internal/fcm_token/usecase.go
+++ b/internal/fcm_token/usecase.go
@@ -37,3 +37,13 @@ func (u *FcmTokenUseCase) RegisterFcmToken(ctx context.Context, memberID int64, 
 		return nil
 	})
 }
+
+// DeleteFcmToken removes a member's token matching the provided value.
+func (u *FcmTokenUseCase) DeleteFcmToken(ctx context.Context, memberID int64, token string) error {
+	return database.WithTransaction(ctx, u.db, func(tx *gorm.DB) error {
+		if err := u.fcmTokenService.DeleteByMemberID(ctx, tx, token, memberID); err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/internal/fcm_token/usecase.go
+++ b/internal/fcm_token/usecase.go
@@ -1,0 +1,39 @@
+package fcm_token
+
+import (
+	"context"
+
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/app/shared/database"
+	"github.com/changhyeonkim/pray-together/go-api-server/internal/member"
+	"gorm.io/gorm"
+)
+
+// FcmTokenUseCase coordinates validation and transactional behavior for FCM token APIs.
+type FcmTokenUseCase struct {
+	db              *gorm.DB
+	memberService   *member.MemberService
+	fcmTokenService *FcmTokenService
+}
+
+// NewFcmTokenUseCase constructs a new use case instance.
+func NewFcmTokenUseCase(db *gorm.DB, memberService *member.MemberService, fcmTokenService *FcmTokenService) *FcmTokenUseCase {
+	return &FcmTokenUseCase{
+		db:              db,
+		memberService:   memberService,
+		fcmTokenService: fcmTokenService,
+	}
+}
+
+// RegisterFcmToken registers a new token for the authenticated member.
+func (u *FcmTokenUseCase) RegisterFcmToken(ctx context.Context, memberID int64, token string) error {
+	return database.WithTransaction(ctx, u.db, func(tx *gorm.DB) error {
+		if err := u.memberService.ValidateMemberExists(ctx, tx, memberID); err != nil {
+			return err
+		}
+
+		if err := u.fcmTokenService.RegisterToken(ctx, tx, memberID, token); err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/internal/model/fcm_token.go
+++ b/internal/model/fcm_token.go
@@ -1,0 +1,17 @@
+package model
+
+// FcmToken represents a Firebase token registered by a member.
+type FcmToken struct {
+	ID       int64   `gorm:"column:id;primaryKey;autoIncrement"`
+	MemberID int64   `gorm:"column:member_id;not null"`
+	Member   *Member `gorm:"foreignKey:MemberID;constraint:OnDelete:CASCADE"`
+	Token    string  `gorm:"column:token;type:VARCHAR2(512);not null"`
+	IsActive bool    `gorm:"column:is_active;not null"`
+
+	BaseEntity
+}
+
+// TableName returns the table name.
+func (*FcmToken) TableName() string {
+	return "fcm_token"
+}


### PR DESCRIPTION
 # 📝 어떤 변경인가요?

  ## 새로운 기능
  - POST /api/v1/fcm-token 엔드포인트 추가 - FCM 토큰 등록/재등록
  - DELETE /api/v1/fcm-token 엔드포인트 추가 - FCM 토큰 삭제
  - FCM 토큰 관리를 위한 완전한 도메인 레이어 구현

  ## 주요 추가 항목
  - `internal/fcm_token/handler.go` - HTTP 요청 처리 및 DTO 검증
  - `internal/fcm_token/usecase.go` - 비즈니스 로직 오케스트레이션 및 트랜잭션 관리
  - `internal/fcm_token/service.go` - FCM 토큰 도메인 서비스
  - `internal/fcm_token/repository.go` - 데이터 접근 레이어
  - `internal/fcm_token/dto.go` - 요청/응답 DTO 정의
  - `internal/model/fcm_token.go` - FCM 토큰 엔티티 모델
  - `internal/app/shared/validator/notblank.go` - 공백 검증 validator 추가

  ---

  # 🎯 변경의 목적은 무엇인가요?

  ## 배경
  사용자에게 푸시 알림을 발송하기 위해 각 회원의 Firebase Cloud Messaging(FCM) 토큰을 서버에서 관리할 필요가 있음

  ## 목적
  - 클라이언트 앱이 FCM 토큰을 서버에 등록/갱신할 수 있도록 API 제공
  - FCM 토큰을 삭제할 수 있는 API 제공
  - 향후 푸시 알림 발송 기능의 기반 인프라 구축
  - 회원별 FCM 토큰 이력 관리 (is_active 플래그로 상태 추적)

  ---

  # 🔧 어떻게 변경되었나요?

  ## 새로운 파일

  ### FCM Token 도메인
  - `internal/fcm_token/handler.go` - RegisterToken, DeleteToken 핸들러 구현
  - `internal/fcm_token/usecase.go` - RegisterFcmToken, DeleteFcmToken 유스케이스
  - `internal/fcm_token/service.go` - RegisterToken, DeleteByMemberID 도메인 서비스
  - `internal/fcm_token/repository.go` - Upsert, DeleteByMemberIDAndToken 데이터 접근
  - `internal/fcm_token/dto.go` - RegisterFcmTokenRequest, DeleteFcmTokenRequest DTO
  - `internal/model/fcm_token.go` - FcmToken 엔티티 (id, member_id, token, is_active)

  ### 테스트
  - `internal/fcm_token/register_fcm_token_api_test.go` - 토큰 등록 API 통합 테스트 (4개)
  - `internal/fcm_token/delete_fcm_token_api_test.go` - 토큰 삭제 API 통합 테스트 (4개)
  - `internal/fcm_token/test_helpers_test.go` - 테스트 환경 셋업 헬퍼

  ### Validator
  - `internal/app/shared/validator/notblank.go` - 공백 문자열 검증 커스텀 validator

  ## 수정된 파일

  | 파일 | 변경 사항 |
  |------|----------|
  | `internal/app/router/routes.go` | FCM 토큰 라우트 및 의존성 주입 추가 |
  | `internal/app/shared/validator/register.go` | notblank validator 등록 |
  | `internal/app/shared/validator/errors.go` | notblank 검증 실패 시 에러 메시지 추가 |
  | `internal/app/shared/testutil/database.go` | FcmToken 모델 마이그레이션 추가 |

  ⚠️ 특이 사항

  🔒 보안

  - 모든 엔드포인트는 JWT 인증 필수
  - 토큰 삭제 시 본인의 토큰만 삭제 가능 (member_id로 필터링)

  📋 배포 시 주의사항

  기타 사항

  - 현재는 토큰 등록/삭제만 구현되었으며, 실제 푸시 알림 발송 기능은 별도 구현 예정
  - 회원 탈퇴 시 FCM 토큰은 CASCADE로 자동 삭제됨

  ---
  🔗 관련 이슈

  close #14